### PR TITLE
Fix deprecated cache action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache-Go
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Cache-Go
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod              # Module download cache


### PR DESCRIPTION
## Summary
- update golangci-lint workflow to use actions/cache@v4 and checkout@v4
- update test workflow to use actions/cache@v4

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858c2e88d20832fa16fb7f7ec9b7ffc