### PR TITLE
Fix golangci-lint workflow timeout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,6 +24,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.60


### PR DESCRIPTION
## Summary
- update golangci-lint GitHub action to v6

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858ce741070832fb99b062663a08c73