### PR TITLE
Fix lint warnings

### DIFF
--- a/appImageGithub.go
+++ b/appImageGithub.go
@@ -169,7 +169,7 @@ func (appImage *AppImageFileInfo) GetInformationFromAppImage(repoName string, ic
 		}()
 	}
 	log.Printf("Got %s", appImage.tempFile)
-	var programName string = appImage.ProgramName
+	programName := appImage.ProgramName
 	if programName == "" {
 		programName = repoName
 	}

--- a/filenameDecode.go
+++ b/filenameDecode.go
@@ -12,7 +12,7 @@ type GroupedFilenamePartMeaning struct {
 }
 
 func (m *GroupedFilenamePartMeaning) Match(s string) bool {
-	if m.FilenamePartMeaning.CaseInsensitive {
+	if m.CaseInsensitive {
 		return strings.EqualFold(s, m.Key)
 	} else {
 		return s == m.Key
@@ -75,13 +75,13 @@ func DecodeFilename(groupedWordMap map[string][]*GroupedFilenamePartMeaning, fil
 						}
 						unmatched = -1
 					}
-					if suffixOnly && !meaning.FilenamePartMeaning.SuffixOnly {
+					if suffixOnly && !meaning.SuffixOnly {
 						continue
 					}
 					var fi = *meaning.FilenamePartMeaning
 					fi.Captured = filename[i : i+keyLen]
 					result = append(result, &fi)
-					if meaning.FilenamePartMeaning.SuffixOnly {
+					if meaning.SuffixOnly {
 						suffixOnly = true
 					}
 					i += keyLen
@@ -95,7 +95,7 @@ func DecodeFilename(groupedWordMap map[string][]*GroupedFilenamePartMeaning, fil
 			if unmatched == -1 {
 				unmatched = i
 			}
-			for i < length && !(filename[i] == '-' || filename[i] == '_' || filename[i] == '.') {
+			for i < length && filename[i] != '-' && filename[i] != '_' && filename[i] != '.' {
 				i++
 			}
 		}

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -85,7 +85,7 @@ func MapStringer(sb *strings.Builder, key string, valueMap map[string][]string) 
 	}
 	sort.Strings(keywords)
 	for _, kw := range keywords {
-		sb.WriteString(fmt.Sprintf("%s %s=>%s\n", key, kw, strings.Join(valueMap[kw], " > ")))
+		fmt.Fprintf(sb, "%s %s=>%s\n", key, kw, strings.Join(valueMap[kw], " > "))
 	}
 }
 
@@ -97,7 +97,7 @@ func MapDoubleStringer(sb *strings.Builder, key string, valueMap map[string][][]
 	sort.Strings(keywords)
 	for _, kw := range keywords {
 		for _, values := range valueMap[kw] {
-			sb.WriteString(fmt.Sprintf("%s %s=>%s\n", key, kw, strings.Join(values, " > ")))
+			fmt.Fprintf(sb, "%s %s=>%s\n", key, kw, strings.Join(values, " > "))
 		}
 	}
 }
@@ -115,7 +115,7 @@ func DoubleMapStringer(sb *strings.Builder, key string, valueMap map[string]map[
 		}
 		sort.Strings(subKeywords)
 		for _, skw := range subKeywords {
-			sb.WriteString(fmt.Sprintf("%s %s:%s=>%s\n", key, kw, skw, strings.Join(valueMap[kw][skw], " > ")))
+			fmt.Fprintf(sb, "%s %s:%s=>%s\n", key, kw, skw, strings.Join(valueMap[kw][skw], " > "))
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- use `fmt.Fprintf` when writing formatted strings to a builder
- simplify access to embedded fields in `filenameDecode`
- apply De Morgan's law in `filenameDecode`
- let the compiler infer the `programName` variable type

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858d205fd08832f89116dc7c8c31f63