### PR TITLE
Ignore folder metadata in CompileMeanings

### DIFF
--- a/binaryGithubRelease.go
+++ b/binaryGithubRelease.go
@@ -636,6 +636,8 @@ func (brfi *BinaryReleaseFileInfo) CompileMeanings(input []*FilenamePartMeaning,
 	simple := true
 	for _, each := range input {
 		switch {
+		case each.Folder:
+			// Folder markers are purely advisory
 		case each.Version:
 			result.Filename += "${VERSION}"
 		case each.Tag:
@@ -645,11 +647,16 @@ func (brfi *BinaryReleaseFileInfo) CompileMeanings(input []*FilenamePartMeaning,
 		case each.ProjectName:
 			result.Filename += each.Captured
 			capturedProjectName = each.Captured
-		case each.Folder:
 		default:
 			simple = false
 			result.Filename += each.Captured
 		}
+
+		if each.Folder {
+			// Ignore keywords and other properties for folder names
+			continue
+		}
+
 		if each.Keyword != "" {
 			if result.Keyword != "" && result.Keyword != each.Keyword {
 				return nil, false

--- a/binaryGithubRelease_test.go
+++ b/binaryGithubRelease_test.go
@@ -121,6 +121,33 @@ func TestBinaryReleaseFileInfo_CompileMeanings(t *testing.T) {
 			},
 			want1: true,
 		},
+		{
+			name: "folder tokens ignored",
+			input: []*FilenamePartMeaning{
+				{Captured: "linux", OS: "linux", Folder: true},
+				{Separator: true, Captured: "-", Folder: true},
+				{Captured: "amd64", Keyword: "~amd64", Folder: true},
+				{Captured: "foo", Unmatched: true},
+			},
+			base: &BinaryReleaseFileInfo{
+				Filename:        "foo",
+				ArchivePathname: "linux-amd64/foo",
+				ExecutableBit:   true,
+			},
+			want: &BinaryReleaseFileInfo{
+				ProgramName:      "foo",
+				OriginalFilename: "foo",
+				ArchivePathname:  "linux-amd64/foo",
+				InstalledName:    "foo",
+				Filename:         "foo",
+				ExecutableBit:    true,
+				Binary:           true,
+				Keyword:          "",
+				OS:               "",
+				SuffixOnly:       true,
+			},
+			want1: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -132,5 +159,44 @@ func TestBinaryReleaseFileInfo_CompileMeanings(t *testing.T) {
 				t.Errorf("CompileMeanings() gotOk = %v, want %v", gotOk, tt.want1)
 			}
 		})
+	}
+}
+
+func TestFindFiles_SubdirectoryBinary(t *testing.T) {
+	wordMap := GroupAndSort(GenerateWordMeanings("foo", nil, nil))
+
+	files := BinaryReleaseFiles{
+		&BinaryReleaseFileInfo{
+			Filename:        "foo",
+			ArchivePathname: "linux-amd64/foo",
+			DirectoryName:   "linux-amd64/",
+			ExecutableBit:   true,
+		},
+	}
+
+	ft := files.FindFiles(wordMap, nil)
+
+	if len(ft.Binaries) != 1 {
+		t.Fatalf("expected 1 binary, got %d", len(ft.Binaries))
+	}
+
+	got := ft.Binaries[0]
+	want := &BinaryReleaseFileInfo{
+		ProgramName:      "foo",
+		OriginalFilename: "foo",
+		ArchivePathname:  "linux-amd64/foo",
+		InstalledName:    "foo",
+		Filename:         "foo",
+		ExecutableBit:    true,
+		Binary:           true,
+		Keyword:          "~amd64",
+		KeywordDefaulted: true,
+		ProjectName:      true,
+		OS:               "",
+		SuffixOnly:       true,
+	}
+
+	if diff := cmp.Diff(got, want, cmpopts.IgnoreUnexported(BinaryReleaseFileInfo{})); diff != "" {
+		t.Fatalf("FindFiles diff:\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- ignore Folder token properties in CompileMeanings
- add tests for folder tokens
- test subdirectory binaries

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858d248992c832faa1e994fef5c990f