### PR TITLE
Support recursive archive extraction

### DIFF
--- a/appImageGithub.go
+++ b/appImageGithub.go
@@ -110,26 +110,11 @@ func GenerateAppImageGithubReleaseConfigEntry(gitRepo, tagOverride, tagPrefix st
 		log.Printf("No app images found, but some archives / compressed files")
 		for _, container := range containers {
 			log.Printf("Searching: %s", container.Filename)
-			archivedFiles, err := container.SearchArchiveForAppImageFiles()
+			layer, err := container.SearchArchiveForAppImageFiles()
 			if err != nil {
-				for _, af := range archivedFiles {
-					if err := os.Remove(af.tempFile); err != nil {
-						log.Printf("Error removing temp file: %s", err)
-					}
-					af.tempFile = ""
-				}
 				return nil, err
 			}
-			nai, nc := AppImageFiles(archivedFiles).ExtractAppImagesAndContainers(wordMap)
-			for _, nce := range nc {
-				if len(nce.tempFile) == 0 {
-					continue
-				}
-				if err := os.Remove(nce.tempFile); err != nil {
-					log.Printf("Error removing temp file: %s", err)
-				}
-				nce.tempFile = ""
-			}
+			nai, _ := ExtractAppImagesFromLayer(layer, wordMap)
 			if len(nai) > 0 {
 				appImages = append(appImages, nai...)
 			}
@@ -237,10 +222,9 @@ func (appImage *AppImageFileInfo) GetInformationFromAppImage(repoName string, ic
 	return nil
 }
 
-func (container *AppImageFileInfo) SearchArchiveForAppImageFiles() ([]*AppImageFileInfo, error) {
+func (container *AppImageFileInfo) SearchArchiveForAppImageFiles() (*ArchiveLayer[*AppImageFileInfo], error) {
 	switch strings.ToLower(strings.Join(container.Containers, ".")) {
 	case "deb", "rpm":
-		// Skip repo archives for the moment.
 		return nil, nil
 	}
 	url := container.ReleaseAsset.GetBrowserDownloadURL()
@@ -259,13 +243,12 @@ func (container *AppImageFileInfo) SearchArchiveForAppImageFiles() ([]*AppImageF
 
 	log.Printf("Got %s => %s", url, container.tempFile)
 
-	var archivedFiles []*AppImageFileInfo
-	// TODO support weirdly nested containers.
+	layer := &ArchiveLayer[*AppImageFileInfo]{Archive: container}
 	switch strings.Join(container.Containers, ".") {
 	case "zip":
 		zf, err := zip.OpenReader(container.tempFile)
 		if err != nil {
-			return archivedFiles, fmt.Errorf("opening zip file: %s: %w", url, err)
+			return layer, fmt.Errorf("opening zip file: %s:%w", url, err)
 		}
 		defer func() {
 			if err := zf.Close(); err != nil {
@@ -273,28 +256,52 @@ func (container *AppImageFileInfo) SearchArchiveForAppImageFiles() ([]*AppImageF
 			}
 		}()
 		for _, f := range zf.File {
+			if f.Mode().IsDir() {
+				continue
+			}
 			zfr, err := f.Open()
 			if err != nil {
-				return archivedFiles, fmt.Errorf("extracting file %s from %s: %w", f.Name, url, err)
+				return layer, fmt.Errorf("extracting file %s from %s: %w", f.Name, url, err)
 			}
 			tmpFile, err := util.SaveReaderToTempFile(zfr)
 			if err != nil {
-				return archivedFiles, fmt.Errorf("saving file %s to temp file: %w", f.Name, err)
+				return layer, fmt.Errorf("saving file %s to temp file: %w", f.Name, err)
 			}
-			defer func() {
-				if err := zfr.Close(); err != nil {
-					log.Printf("error closing zip file %s from %s: %s", f.Name, url, err)
-				}
-			}()
-			archivedFiles = append(archivedFiles, &AppImageFileInfo{
+			if err := zfr.Close(); err != nil {
+				log.Printf("error closing zip file %s from %s: %s", f.Name, url, err)
+			}
+			ai := &AppImageFileInfo{
 				Container:    container.Filename,
 				Filename:     f.Name,
 				tempFile:     tmpFile,
 				ReleaseAsset: container.ReleaseAsset,
-			})
+			}
+			if isArchiveFilename(f.Name) {
+				ai.Containers = containersFromName(f.Name)
+				sub, err := ai.SearchArchiveForAppImageFiles()
+				if err != nil {
+					return layer, err
+				}
+				layer.Layers = append(layer.Layers, sub)
+			} else {
+				layer.Files = append(layer.Files, ai)
+			}
 		}
 	}
-	return archivedFiles, nil
+	return layer, nil
+}
+
+func ExtractAppImagesFromLayer(layer *ArchiveLayer[*AppImageFileInfo], wordMap map[string][]*GroupedFilenamePartMeaning) ([]*AppImageFileInfo, []*AppImageFileInfo) {
+	if layer == nil {
+		return nil, nil
+	}
+	appImages, containers := AppImageFiles(layer.Files).ExtractAppImagesAndContainers(wordMap)
+	for _, sub := range layer.Layers {
+		nai, nc := ExtractAppImagesFromLayer(sub, wordMap)
+		appImages = append(appImages, nai...)
+		containers = append(containers, nc...)
+	}
+	return appImages, containers
 }
 
 type AppImageFiles []*AppImageFileInfo

--- a/archive_layer.go
+++ b/archive_layer.go
@@ -1,0 +1,40 @@
+package arrans_overlay_workflow_builder
+
+import "strings"
+
+type ArchiveLayer[T any] struct {
+	Archive T
+	Files   []T
+	Layers  []*ArchiveLayer[T]
+}
+
+func isArchiveFilename(name string) bool {
+	l := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(l, ".tar"),
+		strings.HasSuffix(l, ".tar.gz"),
+		strings.HasSuffix(l, ".tgz"),
+		strings.HasSuffix(l, ".tar.bz2"),
+		strings.HasSuffix(l, ".tbz2"),
+		strings.HasSuffix(l, ".zip"):
+		return true
+	default:
+		return false
+	}
+}
+
+func containersFromName(name string) []string {
+	l := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(l, ".tar.gz"), strings.HasSuffix(l, ".tgz"):
+		return []string{"tar", "gz"}
+	case strings.HasSuffix(l, ".tar.bz2"), strings.HasSuffix(l, ".tbz2"):
+		return []string{"tar", "bz2"}
+	case strings.HasSuffix(l, ".tar"):
+		return []string{"tar"}
+	case strings.HasSuffix(l, ".zip"):
+		return []string{"zip"}
+	default:
+		return nil
+	}
+}

--- a/binaryGithubRelease.go
+++ b/binaryGithubRelease.go
@@ -129,20 +129,11 @@ func GenerateBinaryGithubReleaseConfigEntry(gitRepo, tagOverride, prefix string)
 		log.Printf("No binaries found, but some archives / compressed files")
 		for _, container := range rootFiles.CompressedArchives {
 			log.Printf("Searching: %s", container.Filename)
-			archivedFiles, err := container.SearchArchiveForFiles()
+			layer, err := container.SearchArchiveForFiles()
 			if err != nil {
 				return nil, err
 			}
-			containerFiles := BinaryReleaseFiles(archivedFiles).FindFiles(wordMap, rootFiles)
-			for _, nce := range containerFiles.CompressedArchives {
-				if len(nce.tempFile) == 0 {
-					continue
-				}
-				if err := os.Remove(nce.tempFile); err != nil {
-					log.Printf("Error removing temp file: %s", err)
-				}
-				nce.tempFile = ""
-			}
+			containerFiles := FindFilesArchiveLayer(layer, wordMap, rootFiles)
 			rootFiles.CompressedArchiveContent[container.Filename] = containerFiles
 		}
 	}
@@ -247,10 +238,9 @@ func GenerateBinaryGithubReleaseConfigEntry(gitRepo, tagOverride, prefix string)
 	return ic, nil
 }
 
-func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFileInfo, error) {
+func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() (*ArchiveLayer[*BinaryReleaseFileInfo], error) {
 	switch strings.ToLower(strings.Join(brfi.Containers, ".")) {
 	case "deb", "rpm":
-		// Skip repo archives for the moment.
 		return nil, nil
 	}
 	url, err := brfi.FetchContent()
@@ -258,14 +248,14 @@ func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFile
 		return nil, err
 	}
 
-	var archivedFiles []*BinaryReleaseFileInfo
-	// TODO support weirdly nested containers.
+	layer := &ArchiveLayer[*BinaryReleaseFileInfo]{Archive: brfi}
+
 	switch strings.ToLower(strings.Join(brfi.Containers, ".")) {
 	case "tar.gz", "tar.bz2", "tar":
 		var cr io.Reader
 		f, err := os.Open(brfi.tempFile)
 		if err != nil {
-			return archivedFiles, fmt.Errorf("opening file: %s: %w", url, err)
+			return layer, fmt.Errorf("opening file: %s: %w", url, err)
 		}
 		defer func() {
 			if err := f.Close(); err != nil {
@@ -278,12 +268,12 @@ func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFile
 			case "gz":
 				cr, err = gzip.NewReader(f)
 				if err != nil {
-					return archivedFiles, fmt.Errorf("opening gzip file: %s: %w", url, err)
+					return layer, fmt.Errorf("opening gzip file: %s: %w", url, err)
 				}
 			case "bz2":
 				cr = bzip2.NewReader(f)
 			default:
-				return archivedFiles, fmt.Errorf("unknown format for file: %s", url)
+				return layer, fmt.Errorf("unknown format for file: %s", url)
 			}
 		} else {
 			cr = f
@@ -296,17 +286,17 @@ func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFile
 				break
 			}
 			if err != nil {
-				return archivedFiles, fmt.Errorf("reading next tar file: %s: %w", url, err)
+				return layer, fmt.Errorf("reading next tar file: %s: %w", url, err)
 			}
 			if zfh.FileInfo().IsDir() {
 				continue
 			}
 			tmpFile, err := util.SaveReaderToTempFile(tr)
 			if err != nil {
-				return archivedFiles, fmt.Errorf("extracting file %s from %s: %w", zfh.Name, url, err)
+				return layer, fmt.Errorf("extracting file %s from %s: %w", zfh.Name, url, err)
 			}
 			dir, fn := path.Split(zfh.Name)
-			archivedFiles = append(archivedFiles, &BinaryReleaseFileInfo{
+			file := &BinaryReleaseFileInfo{
 				Container:       brfi,
 				ArchivePathname: zfh.Name,
 				DirectoryName:   dir,
@@ -314,12 +304,22 @@ func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFile
 				tempFile:        tmpFile,
 				ReleaseAsset:    brfi.ReleaseAsset,
 				ExecutableBit:   (zfh.Mode & 0o0500) == 0o0500,
-			})
+			}
+			if isArchiveFilename(fn) {
+				file.Containers = containersFromName(fn)
+				sub, err := file.SearchArchiveForFiles()
+				if err != nil {
+					return layer, err
+				}
+				layer.Layers = append(layer.Layers, sub)
+			} else {
+				layer.Files = append(layer.Files, file)
+			}
 		}
 	case "zip":
 		zf, err := zip.OpenReader(brfi.tempFile)
 		if err != nil {
-			return archivedFiles, fmt.Errorf("opening zip file: %s: %w", url, err)
+			return layer, fmt.Errorf("opening zip file: %s:%w", url, err)
 		}
 		defer func() {
 			if err := zf.Close(); err != nil {
@@ -332,19 +332,17 @@ func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFile
 			}
 			zfr, err := f.Open()
 			if err != nil {
-				return archivedFiles, fmt.Errorf("extracting file %s from %s: %w", f.Name, url, err)
+				return layer, fmt.Errorf("extracting file %s from %s: %w", f.Name, url, err)
 			}
 			tmpFile, err := util.SaveReaderToTempFile(zfr)
 			if err != nil {
-				return archivedFiles, fmt.Errorf("saving file %s to temp file: %w", f.Name, err)
+				return layer, fmt.Errorf("saving file %s to temp file: %w", f.Name, err)
 			}
-			defer func() {
-				if err := zfr.Close(); err != nil {
-					log.Printf("error closing zip file %s from %s: %s", f.Name, url, err)
-				}
-			}()
+			if err := zfr.Close(); err != nil {
+				log.Printf("error closing zip file %s from %s: %s", f.Name, url, err)
+			}
 			dir, fn := path.Split(f.Name)
-			archivedFiles = append(archivedFiles, &BinaryReleaseFileInfo{
+			file := &BinaryReleaseFileInfo{
 				Container:       brfi,
 				ArchivePathname: f.Name,
 				Filename:        fn,
@@ -352,10 +350,20 @@ func (brfi *BinaryReleaseFileInfo) SearchArchiveForFiles() ([]*BinaryReleaseFile
 				tempFile:        tmpFile,
 				ReleaseAsset:    brfi.ReleaseAsset,
 				ExecutableBit:   (f.Mode().Perm() & 0o500) == 0o500,
-			})
+			}
+			if isArchiveFilename(fn) {
+				file.Containers = containersFromName(fn)
+				sub, err := file.SearchArchiveForFiles()
+				if err != nil {
+					return layer, err
+				}
+				layer.Layers = append(layer.Layers, sub)
+			} else {
+				layer.Files = append(layer.Files, file)
+			}
 		}
 	}
-	return archivedFiles, nil
+	return layer, nil
 }
 
 func (brfi *BinaryReleaseFileInfo) close() {
@@ -501,6 +509,18 @@ func (t *FileTypes) Free() {
 	}
 }
 
+func FindFilesArchiveLayer(layer *ArchiveLayer[*BinaryReleaseFileInfo], wordMap map[string][]*GroupedFilenamePartMeaning, root *FileTypes) *FileTypes {
+	if layer == nil {
+		return &FileTypes{}
+	}
+	result := BinaryReleaseFiles(layer.Files).FindFiles(wordMap, root)
+	for _, sub := range layer.Layers {
+		subFiles := FindFilesArchiveLayer(sub, wordMap, result)
+		result.CompressedArchiveContent[sub.Archive.Filename] = subFiles
+	}
+	return result
+
+}
 func (bases BinaryReleaseFiles) FindFiles(wordMap map[string][]*GroupedFilenamePartMeaning, root *FileTypes) *FileTypes {
 	result := &FileTypes{
 		CompressedArchives:       []*BinaryReleaseFileInfo{},

--- a/binaryGithubRelease_test.go
+++ b/binaryGithubRelease_test.go
@@ -1,8 +1,14 @@
 package arrans_overlay_workflow_builder
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -132,5 +138,77 @@ func TestBinaryReleaseFileInfo_CompileMeanings(t *testing.T) {
 				t.Errorf("CompileMeanings() gotOk = %v, want %v", gotOk, tt.want1)
 			}
 		})
+	}
+}
+
+func TestSearchArchiveForFiles_Multilayer(t *testing.T) {
+	tmp := t.TempDir()
+
+	innerZipPath := filepath.Join(tmp, "inner.zip")
+	zf, err := os.Create(innerZipPath)
+	if err != nil {
+		t.Fatalf("create inner zip: %v", err)
+	}
+	zw := zip.NewWriter(zf)
+	w, err := zw.Create("prog")
+	if err != nil {
+		t.Fatalf("create file in zip: %v", err)
+	}
+	if _, err := w.Write([]byte("data")); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	if err := zf.Close(); err != nil {
+		t.Fatalf("close zip file: %v", err)
+	}
+
+	outerPath := filepath.Join(tmp, "outer.tar.gz")
+	of, err := os.Create(outerPath)
+	if err != nil {
+		t.Fatalf("create outer tar: %v", err)
+	}
+	gw := gzip.NewWriter(of)
+	tw := tar.NewWriter(gw)
+	innerFile, err := os.Open(innerZipPath)
+	if err != nil {
+		t.Fatalf("open inner zip: %v", err)
+	}
+	stat, _ := innerFile.Stat()
+	hdr := &tar.Header{Name: "inner.zip", Mode: 0644, Size: stat.Size()}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := io.Copy(tw, innerFile); err != nil {
+		t.Fatalf("copy inner: %v", err)
+	}
+	innerFile.Close()
+	tw.Close()
+	gw.Close()
+	of.Close()
+
+	brfi := &BinaryReleaseFileInfo{
+		Filename:   "outer.tar.gz",
+		Containers: []string{"tar", "gz"},
+		tempFile:   outerPath,
+	}
+
+	layer, err := brfi.SearchArchiveForFiles()
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(layer.Layers) != 1 {
+		t.Fatalf("expected 1 sub layer got %d", len(layer.Layers))
+	}
+	inner := layer.Layers[0]
+	if inner.Archive.Filename != "inner.zip" {
+		t.Errorf("inner archive name %s", inner.Archive.Filename)
+	}
+	if len(inner.Files) != 1 {
+		t.Fatalf("expected 1 file inside, got %d", len(inner.Files))
+	}
+	if inner.Files[0].Filename != "prog" {
+		t.Errorf("inner file name %s", inner.Files[0].Filename)
 	}
 }


### PR DESCRIPTION
## Summary
- create `ArchiveLayer` for nested archives
- recursively unpack archives in binary and AppImage search functions
- traverse nested archive layers in `FindFilesArchiveLayer` and `ExtractAppImagesFromLayer`
- add test for multi-layer archive extraction

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858d237aaec832f87ff3cf860d9ce78