### PR TITLE
Handle missing releases in jq

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -67,7 +67,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+            tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
 [[- if .WorkaroundSemanticVersionWithoutV ]]
           for tag in $tags; do
             version="${tag}"

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -67,7 +67,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p $ebuild_dir
           declare -A releaseTypes=()
-          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[].tag_name')
+          tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
 [[- if .WorkaroundSemanticVersionWithoutV ]]
           for tag in $tags; do
             version="${tag}"


### PR DESCRIPTION
## Summary
- safeguard jq release tag parsing for GitHub workflows

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aaf2a49f48832fb036a3ec184038bb