### PR TITLE
Prefer primary AppImage asset

### DIFF
--- a/appImageGithub.go
+++ b/appImageGithub.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 type AppImageFileInfo struct {
@@ -141,6 +142,7 @@ func GenerateAppImageGithubReleaseConfigEntry(gitRepo, tagOverride, tagPrefix st
 	if ic.Programs == nil {
 		ic.Programs = map[string]*Program{}
 	}
+	appImages = selectPrimaryAppImage(appImages, repoName)
 	for _, appImage := range appImages {
 		if err := appImage.GetInformationFromAppImage(repoName, ic); err != nil {
 			return nil, err
@@ -148,6 +150,85 @@ func GenerateAppImageGithubReleaseConfigEntry(gitRepo, tagOverride, tagPrefix st
 		// Desktop icon: ai.Desktop.Section("Desktop Entry").Key("Icon").Value()
 	}
 	return ic, nil
+}
+
+func selectPrimaryAppImage(appImages []*AppImageFileInfo, repoName string) []*AppImageFileInfo {
+	if len(appImages) <= 1 {
+		return appImages
+	}
+	repoNorm := normalizeName(repoName)
+	sort.Slice(appImages, func(i, j int) bool {
+		ai, aj := appImages[i], appImages[j]
+		key := func(a *AppImageFileInfo) (int, int) {
+			norm := normalizeName(a.ProgramName)
+			switch {
+			case norm == repoNorm:
+				return 0, 0
+			case a.ProgramName == "":
+				return 1, 0
+			default:
+				return 2, stringDistance(norm, repoNorm)
+			}
+		}
+		ki1, ki2 := key(ai)
+		kj1, kj2 := key(aj)
+		if ki1 != kj1 {
+			return ki1 < kj1
+		}
+		if ki2 != kj2 {
+			return ki2 < kj2
+		}
+		return ai.OriginalFilename < aj.OriginalFilename
+	})
+	log.Printf("Multiple AppImages found, using %s", appImages[0].OriginalFilename)
+	return []*AppImageFileInfo{appImages[0]}
+}
+
+func normalizeName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
+}
+
+func stringDistance(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	la, lb := len(ra), len(rb)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	dp := make([][]int, la+1)
+	for i := range dp {
+		dp[i] = make([]int, lb+1)
+	}
+	for i := 0; i <= la; i++ {
+		dp[i][0] = i
+	}
+	for j := 0; j <= lb; j++ {
+		dp[0][j] = j
+	}
+	for i := 1; i <= la; i++ {
+		for j := 1; j <= lb; j++ {
+			cost := 0
+			if ra[i-1] != rb[j-1] {
+				cost = 1
+			}
+			dp[i][j] = dp[i-1][j-1] + cost
+			if dp[i][j-1]+1 < dp[i][j] {
+				dp[i][j] = dp[i][j-1] + 1
+			}
+			if dp[i-1][j]+1 < dp[i][j] {
+				dp[i][j] = dp[i-1][j] + 1
+			}
+		}
+	}
+	return dp[la][lb]
 }
 
 func (appImage *AppImageFileInfo) GetInformationFromAppImage(repoName string, ic *InputConfig) error {

--- a/appImageGithub_test.go
+++ b/appImageGithub_test.go
@@ -152,3 +152,72 @@ func TestCompileMeanings(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectPrimaryAppImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      string
+		input     []*AppImageFileInfo
+		wantFirst string
+	}{
+		{
+			name: "prefer repo name match",
+			repo: "example",
+			input: []*AppImageFileInfo{
+				{ProgramName: "other", OriginalFilename: "other.AppImage"},
+				{ProgramName: "example", OriginalFilename: "example.AppImage"},
+				{ProgramName: "third", OriginalFilename: "third.AppImage"},
+			},
+			wantFirst: "example.AppImage",
+		},
+		{
+			name: "prefer blank when no match",
+			repo: "example",
+			input: []*AppImageFileInfo{
+				{ProgramName: "foo", OriginalFilename: "foo.AppImage"},
+				{ProgramName: "", OriginalFilename: "example.AppImage"},
+				{ProgramName: "bar", OriginalFilename: "bar.AppImage"},
+			},
+			wantFirst: "example.AppImage",
+		},
+		{
+			name: "fallback to closest name",
+			repo: "example",
+			input: []*AppImageFileInfo{
+				{ProgramName: "sample", OriginalFilename: "sample.AppImage"},
+				{ProgramName: "exampel", OriginalFilename: "exampel.AppImage"},
+				{ProgramName: "another", OriginalFilename: "another.AppImage"},
+			},
+			wantFirst: "exampel.AppImage",
+		},
+		{
+			name: "match ignoring case",
+			repo: "Example",
+			input: []*AppImageFileInfo{
+				{ProgramName: "EXAMPLE", OriginalFilename: "EXAMPLE.AppImage"},
+				{ProgramName: "other", OriginalFilename: "other.AppImage"},
+			},
+			wantFirst: "EXAMPLE.AppImage",
+		},
+		{
+			name: "match camel and snake case",
+			repo: "exampleApp",
+			input: []*AppImageFileInfo{
+				{ProgramName: "example_app", OriginalFilename: "example_app.AppImage"},
+				{ProgramName: "sample", OriginalFilename: "sample.AppImage"},
+			},
+			wantFirst: "example_app.AppImage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectPrimaryAppImage(tt.input, tt.repo)
+			if len(got) != 1 {
+				t.Fatalf("len(got) = %d, want 1", len(got))
+			}
+			if got[0].OriginalFilename != tt.wantFirst {
+				t.Fatalf("got %s, want %s", got[0].OriginalFilename, tt.wantFirst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- normalize AppImage program names to ignore case and separators when selecting primary asset
- add tests for case-insensitive and snake/camel-case matching in AppImage selection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac203cda58832f9f2f0cda5cffe7c3