### PR TITLE
Add default FUSE dependency to AppImage workflows

### DIFF
--- a/generateGithubAppImageWorkflow.go
+++ b/generateGithubAppImageWorkflow.go
@@ -27,12 +27,12 @@ func (ggaitd *GenerateGithubAppImageTemplateData) KeywordList() []string {
 }
 
 func (ggaitd *GenerateGithubAppImageTemplateData) Dependencies() []string {
-	keywords := make([]string, 0)
+	keywords := []string{"sys-fs/fuse:0"}
 	for programName := range ggaitd.Programs {
 		keywords = append(keywords, ggaitd.Programs[programName].Dependencies...)
 	}
 	sort.Strings(keywords)
-	return keywords
+	return slices.Compact(keywords)
 }
 
 func (ggaitd *GenerateGithubAppImageTemplateData) Keywords() string {

--- a/generateGithubAppImageWorkflow.go
+++ b/generateGithubAppImageWorkflow.go
@@ -27,12 +27,12 @@ func (ggaitd *GenerateGithubAppImageTemplateData) KeywordList() []string {
 }
 
 func (ggaitd *GenerateGithubAppImageTemplateData) Dependencies() []string {
-	keywords := []string{"sys-fs/fuse:0"}
-	for programName := range ggaitd.Programs {
-		keywords = append(keywords, ggaitd.Programs[programName].Dependencies...)
+	deps := []string{"sys-fs/fuse:0"}
+	for _, program := range ggaitd.Programs {
+		deps = append(deps, program.Dependencies...)
 	}
-	sort.Strings(keywords)
-	return slices.Compact(keywords)
+	sort.Strings(deps)
+	return slices.Compact(deps)
 }
 
 func (ggaitd *GenerateGithubAppImageTemplateData) Keywords() string {

--- a/generateGithubAppImageWorkflow_test.go
+++ b/generateGithubAppImageWorkflow_test.go
@@ -143,3 +143,53 @@ func TestExternalResourcesToArchivedResourceNameConsistency(t *testing.T) {
 		})
 	}
 }
+
+func TestAppImageDependenciesIncludeFuseByDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name: "defaults to fuse when none provided",
+			input: "Type Github AppImage Release\nGithubProjectUrl https://github.com/example/example/\nCategory app-misc\n" +
+				"EbuildName example-appimage\nDescription Example appimage\nHomepage https://example.com\nLicense MIT\nProgramName example\n" +
+				"Binary amd64=>example-${TAG}.AppImage > example.AppImage\n",
+			expected: []string{"sys-fs/fuse:0"},
+		},
+		{
+			name: "deduplicates fuse when supplied",
+			input: "Type Github AppImage Release\nGithubProjectUrl https://github.com/example/example/\nCategory app-misc\n" +
+				"EbuildName example-appimage\nDescription Example appimage\nHomepage https://example.com\nLicense MIT\nProgramName example\n" +
+				"Dependencies sys-fs/fuse:0 sys-libs/zlib\n" +
+				"Binary amd64=>example-${TAG}.AppImage > example.AppImage\n",
+			expected: []string{"sys-fs/fuse:0", "sys-libs/zlib"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			configs, err := ParseInputConfigReader(bytes.NewReader([]byte(tc.input)))
+			if err != nil {
+				t.Fatalf("ParseInputConfigReader() error = %v", err)
+			}
+			if len(configs) != 1 {
+				t.Fatalf("expected 1 config, got %d", len(configs))
+			}
+
+			data := &GenerateGithubAppImageTemplateData{
+				GenerateGithubWorkflowBase: &GenerateGithubWorkflowBase{InputConfig: configs[0]},
+			}
+
+			deps := data.Dependencies()
+			if diff := cmp.Diff(tc.expected, deps); diff != "" {
+				t.Fatalf("Dependencies() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- include sys-fs/fuse:0 by default when rendering AppImage workflow dependencies
- de-duplicate dependency lists after adding the required FUSE entry
- add coverage to ensure AppImage dependencies include FUSE even when omitted or duplicated

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a91d9f7f0832f8ea01122fca1bf68)