### PR TITLE
Update workflow templates to use g2 metadata

### DIFF
--- a/generateGithubBinaryWorkflow.go
+++ b/generateGithubBinaryWorkflow.go
@@ -727,3 +727,47 @@ func (ggbtd *GenerateGithubBinaryTemplateData) Metadata() (string, error) {
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 %s`, string(o)), nil
 }
+
+func (ggbtd *GenerateGithubBinaryTemplateData) G2MetadataArgs() string {
+	args := ggbtd.GenerateGithubWorkflowBase.G2MetadataArgs() + " "
+
+	var uses []g2.Flag
+	for _, u := range ggbtd.IUse {
+		uses = append(uses, g2.Flag{Name: u})
+	}
+	for _, u := range ggbtd.RequiredUse {
+		uses = append(uses, g2.Flag{Name: u})
+	}
+
+	for pName, progs := range ggbtd.Programs {
+		for keyword := range progs.Binary {
+			for _, mhu := range ggbtd.GetMustHaveUseFlags(pName, keyword) {
+				uses = append(uses, g2.Flag{Name: mhu})
+			}
+			for _, mhu := range ggbtd.GetMustntHaveUseFlags(pName, keyword) {
+				uses = append(uses, g2.Flag{Name: mhu})
+			}
+		}
+	}
+
+	// Filter unique flags
+	seen := make(map[string]bool)
+	var finalUses []g2.Flag
+	for _, f := range uses {
+		cleaned := strcase.SnakeCase(f.Name)
+		if cleaned != "" && !seen[cleaned] {
+			seen[cleaned] = true
+			finalUses = append(finalUses, g2.Flag{Name: cleaned, Text: fmt.Sprintf("Enable %s", cleaned)})
+		}
+	}
+
+	// Sort flags for determinism
+	sort.Slice(finalUses, func(i, j int) bool {
+		return finalUses[i].Name < finalUses[j].Name
+	})
+
+	for _, f := range finalUses {
+		args += fmt.Sprintf(`--use-add "%s:%s" `, f.Name, f.Text)
+	}
+	return strings.TrimSpace(args)
+}

--- a/generateGithubBinaryWorkflow.go
+++ b/generateGithubBinaryWorkflow.go
@@ -729,36 +729,38 @@ func (ggbtd *GenerateGithubBinaryTemplateData) Metadata() (string, error) {
 }
 
 func (ggbtd *GenerateGithubBinaryTemplateData) G2MetadataArgs() string {
+	if ggbtd == nil || ggbtd.GenerateGithubWorkflowBase == nil {
+		return ""
+	}
 	args := ggbtd.GenerateGithubWorkflowBase.G2MetadataArgs() + " "
 
-	var uses []g2.Flag
-	for _, u := range ggbtd.IUse {
-		uses = append(uses, g2.Flag{Name: u})
-	}
-	for _, u := range ggbtd.RequiredUse {
-		uses = append(uses, g2.Flag{Name: u})
-	}
-
-	for pName, progs := range ggbtd.Programs {
-		for keyword := range progs.Binary {
-			for _, mhu := range ggbtd.GetMustHaveUseFlags(pName, keyword) {
-				uses = append(uses, g2.Flag{Name: mhu})
-			}
-			for _, mhu := range ggbtd.GetMustntHaveUseFlags(pName, keyword) {
-				uses = append(uses, g2.Flag{Name: mhu})
-			}
-		}
-	}
-
-	// Filter unique flags
 	seen := make(map[string]bool)
-	var finalUses []g2.Flag
-	for _, f := range uses {
-		cleaned := strcase.SnakeCase(f.Name)
+
+	type flag struct {
+		Name string
+		Text string
+	}
+	var finalUses []flag
+
+	addFlag := func(name, text string) {
+		cleaned := strcase.SnakeCase(name)
 		if cleaned != "" && !seen[cleaned] {
 			seen[cleaned] = true
-			finalUses = append(finalUses, g2.Flag{Name: cleaned, Text: fmt.Sprintf("Enable %s", cleaned)})
+			finalUses = append(finalUses, flag{Name: cleaned, Text: text})
 		}
+	}
+
+	for use := range ggbtd.ReverseProgramsAsAlternatives() {
+		addFlag(use, fmt.Sprintf("Install %s binary", use))
+	}
+	for _, shell := range ggbtd.ShellCompletionShells() {
+		addFlag(shell, fmt.Sprintf("Install %s completion", shell))
+	}
+	for _, use := range ggbtd.IUse {
+		addFlag(use, fmt.Sprintf("Enable %s", use))
+	}
+	for _, use := range ggbtd.ExtractedUseFlags() {
+		addFlag(use, fmt.Sprintf("Enable %s", use))
 	}
 
 	// Sort flags for determinism
@@ -767,7 +769,7 @@ func (ggbtd *GenerateGithubBinaryTemplateData) G2MetadataArgs() string {
 	})
 
 	for _, f := range finalUses {
-		args += fmt.Sprintf(`--use-add "%s:%s" `, f.Name, f.Text)
+		args += fmt.Sprintf("--use-add \"%s:%s\" ", f.Name, f.Text)
 	}
 	return strings.TrimSpace(args)
 }

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -184,14 +184,21 @@ func (b *GenerateGithubWorkflowBase) DefaultMetadata() (string, error) {
 }
 
 func (b *GenerateGithubWorkflowBase) G2MetadataArgs() string {
+	if b == nil {
+		return ""
+	}
 	args := ""
 	if b.MaintainerEmail != "" {
-		args += fmt.Sprintf(`-m "%s:%s:person" `, b.MaintainerEmail, b.MaintainerName)
+		email := strings.ReplaceAll(strings.ReplaceAll(b.MaintainerEmail, "\\", "\\\\"), "\"", "\\\"")
+		name := strings.ReplaceAll(strings.ReplaceAll(b.MaintainerName, "\\", "\\\\"), "\"", "\\\"")
+		args += fmt.Sprintf("-m \"%s:%s:person\" ", email, name)
 	} else {
-		args += `-m "gentoo@arran4.com:Arran Ubels:person" `
+		args += "-m \"gentoo@arran4.com:Arran Ubels:person\" "
 	}
 	if b.GithubOwner != "" && b.GithubRepo != "" {
-		args += fmt.Sprintf(`-u "github:%s/%s" `, b.GithubOwner, b.GithubRepo)
+		owner := strings.ReplaceAll(strings.ReplaceAll(b.GithubOwner, "\\", "\\\\"), "\"", "\\\"")
+		repo := strings.ReplaceAll(strings.ReplaceAll(b.GithubRepo, "\\", "\\\\"), "\"", "\\\"")
+		args += fmt.Sprintf("-u \"github:%s/%s\" ", owner, repo)
 	}
 	return strings.TrimSpace(args)
 }

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -183,6 +183,19 @@ func (b *GenerateGithubWorkflowBase) DefaultMetadata() (string, error) {
 %s`, string(o)), nil
 }
 
+func (b *GenerateGithubWorkflowBase) G2MetadataArgs() string {
+	args := ""
+	if b.MaintainerEmail != "" {
+		args += fmt.Sprintf(`-m "%s:%s:person" `, b.MaintainerEmail, b.MaintainerName)
+	} else {
+		args += `-m "gentoo@arran4.com:Arran Ubels:person" `
+	}
+	if b.GithubOwner != "" && b.GithubRepo != "" {
+		args += fmt.Sprintf(`-u "github:%s/%s" `, b.GithubOwner, b.GithubRepo)
+	}
+	return strings.TrimSpace(args)
+}
+
 func (ic *InputConfig) GenerateGithubWorkflow(file string, now time.Time, templates *template.Template, outputDir, version string) error {
 	if err := ic.Validate(); err != nil {
 		return fmt.Errorf("for %s validating config: %w", ic.EbuildName, err)

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -69,9 +69,7 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           if [ ! -f "$metadata_file" ]; then
-            cat <<EOF > "$metadata_file"
-[[ .DefaultMetadata ]]
-EOF
+            g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           fi
           declare -A releaseTypes=()
             tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -68,9 +68,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
-          fi
+          g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           declare -A releaseTypes=()
             tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -69,9 +69,7 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           if [ ! -f "$metadata_file" ]; then
-            cat <<EOF > "$metadata_file"
-[[ .Metadata ]]
-EOF
+            g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           fi
           declare -A releaseTypes=()
           tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -68,9 +68,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
-          fi
+          g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           declare -A releaseTypes=()
           tags=$(curl -s  --header "Accept: application/vnd.github+json" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" https://api.github.com/repos/${{ env.github_owner }}/${{ env.github_repo }}/releases | jq -r '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -81,9 +81,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          if [ ! -f "$metadata_file" ]; then
-            g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
-          fi
+          g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
           if [ ! -f "$ebuild_file" ]; then
             # shellcheck disable=SC2016

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -82,9 +82,7 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           if [ ! -f "$metadata_file" ]; then
-            cat <<EOF > "$metadata_file"
-[[ .DefaultMetadata ]]
-EOF
+            g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           fi
           ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
           if [ ! -f "$ebuild_file" ]; then


### PR DESCRIPTION
Update workflow templates to use g2 metadata instead of heredoc XML blocks

This patch updates the GitHub Actions workflow templates (`github-binary`, `github-appimage`, `web-appimage`) to use the `g2 metadata` CLI command for generating `metadata.xml` instead of embedding unindented XML blocks via bash heredocs, which was causing YAML parsing errors and missing maintainer configurations.

It introduces `G2MetadataArgs` in `generateWorkflows.go` and `generateGithubBinaryWorkflow.go` to construct the CLI arguments correctly based on `InputConfig`.

---
*PR created automatically by Jules for task [13641942298076056266](https://jules.google.com/task/13641942298076056266) started by @arran4*