### PR TITLE
Replace pkgcraft-tools with g2 cache generate

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -55,9 +55,6 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y wget jq coreutils
-            url=$(curl -s --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/pkgcraft/pkgcraft/releases" | jq -r '[.[] | select(.tag_name | startswith("pkgcraft-tools-"))][0].assets[] | .browser_download_url' | grep "x86_64-unknown-linux-gnu.tar.xz")
-            curl -sL $url | tar xJ
-            sudo mv pk /usr/local/bin/
 
       - name: Install g2
         uses: arran4/g2-action@v1.2
@@ -265,7 +262,7 @@ EOF
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
-          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; pk repo metadata regen .
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -55,9 +55,6 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y wget jq coreutils
-            url=$(curl -s --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/pkgcraft/pkgcraft/releases" | jq -r '[.[] | select(.tag_name | startswith("pkgcraft-tools-"))][0].assets[] | .browser_download_url' | grep "x86_64-unknown-linux-gnu.tar.xz")
-            curl -sL $url | tar xJ
-            sudo mv pk /usr/local/bin/
 
       - name: Install g2
         uses: arran4/g2-action@v1.2
@@ -291,7 +288,7 @@ EOF
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
-          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; pk repo metadata regen .
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
           git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -43,9 +43,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y wget jq coreutils htmlq
-          url=$(curl -s --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/pkgcraft/pkgcraft/releases" | jq -r '[.[] | select(.tag_name | startswith("pkgcraft-tools-"))][0].assets[] | .browser_download_url' | grep "x86_64-unknown-linux-gnu.tar.xz")
-          curl -sL $url | tar xJ
-          sudo mv pk /usr/local/bin/
 
       - name: Install g2
         uses: arran4/g2-action@v1.2
@@ -177,7 +174,7 @@ EOF
       - name: Commit and push changes
         run: |
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
-          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; pk repo metadata regen .
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
           git add metadata/md5-cache/ || true
           if git commit -m "Add ebuild for version ${version}"; then


### PR DESCRIPTION
This commit updates the GitHub Action workflow templates to utilize `g2 cache generate` rather than `pk repo metadata regen` for ebuild cache data generation.
By targeting the cache generation specifically to the project being built (`"${{ env.ecn }}/${{ env.epn }}"`), the process is made more focused and efficient. The unnecessary download and installation of `pkgcraft-tools` has also been removed.

---
*PR created automatically by Jules for task [17070738594624542394](https://jules.google.com/task/17070738594624542394) started by @arran4*