### PR TITLE
docs: remove outdated g2 integration note from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,6 @@ grab the current build number, which we don't. This will remain unsupported for 
 # Notes
 
 * The program has been extended without being refactored beyond its original purpose, I am keen to get someone who has a better design to weigh in, create a PR, or a discussion
-* In the future, the app should (hopefully will) call itself or my app [g2](https://github.com/arran4/g2) for the ebuild generation component of the workflow
 * this tool is for VERY specific use cases. You will have to be prepared to modify it for yours if not included
 * This program is provided under the "good enough for my itch" philosophy. You're welcome to fork, create pull requests and extend as needed.
 * I will be concerned mostly with the apps of my interest, the list can be found here: https://github.com/arran4/arrans_overlay/blob/main/current.config


### PR DESCRIPTION
This pull request removes an outdated note in the `readme.md` regarding future integration with `g2` or `g2-action`. 

As confirmed by reviewing the template files (`templates/github-appimage.tmpl`, `templates/github-binary.tmpl`, `templates/web-appimage.tmpl`), the `arran4/g2-action@v1.2` action is already the established standard for executing cache generation and linting within the generated CI workflows. Therefore, the statement in the readme has been fulfilled and is no longer necessary.

---
*PR created automatically by Jules for task [7714472916078688387](https://jules.google.com/task/7714472916078688387) started by @arran4*