### PR TITLE
feat(web-appimage): Add DownloadRedirect support and fix htmlq install

### DIFF
--- a/inputconfig.go
+++ b/inputconfig.go
@@ -216,6 +216,7 @@ type InputConfig struct {
 	Type             string
 	GithubProjectUrl string
 	DownloadPageUrl  string
+	DownloadRedirect string
 	DownloadMatch    string
 	Category         string
 	EbuildName       string
@@ -264,6 +265,9 @@ func (ic *InputConfig) String() string {
 	case "Web AppImage":
 		if ic.DownloadPageUrl != "" {
 			fmt.Fprintf(&sb, "DownloadPageUrl %s\n", ic.DownloadPageUrl)
+		}
+		if ic.DownloadRedirect != "" {
+			fmt.Fprintf(&sb, "DownloadRedirect %s\n", ic.DownloadRedirect)
 		}
 		if ic.DownloadMatch != "" {
 			fmt.Fprintf(&sb, "DownloadMatch %s\n", ic.DownloadMatch)
@@ -404,6 +408,7 @@ func ParseInputConfigReader(file io.Reader) ([]*InputConfig, error) {
 				"Type":                  nil,
 				"GithubProjectUrl":      nil,
 				"DownloadPageUrl":       nil,
+				"DownloadRedirect":      nil,
 				"DownloadMatch":         nil,
 				"Category":              {DefaultCategory},
 				"EbuildName":            nil,
@@ -524,9 +529,15 @@ func CreateSanitizeAndAppendInputConfig(parsedFields map[string][]string, parsed
 	}
 	switch currentConfig.Type {
 	case "Web AppImage":
-		currentConfig.DownloadPageUrl, err = onlyOrFail(parsedFields["DownloadPageUrl"])
+		currentConfig.DownloadRedirect, err = emptyOrOnlyOrFail(parsedFields["DownloadRedirect"])
 		if err != nil {
-			return nil, fmt.Errorf("on DownloadPageUrl: %v: %w", parsedFields["DownloadPageUrl"], err)
+			return nil, fmt.Errorf("on DownloadRedirect: %v: %w", parsedFields["DownloadRedirect"], err)
+		}
+		if currentConfig.DownloadRedirect == "" {
+			currentConfig.DownloadPageUrl, err = onlyOrFail(parsedFields["DownloadPageUrl"])
+			if err != nil {
+				return nil, fmt.Errorf("on DownloadPageUrl: %v: %w", parsedFields["DownloadPageUrl"], err)
+			}
 		}
 		currentConfig.DownloadMatch, err = emptyOrOnlyOrFail(parsedFields["DownloadMatch"])
 		if err != nil {

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget jq coreutils
           [[- if not .DownloadRedirect ]]
-          curl -sL https://github.com/mgdm/htmlq/releases/latest/download/htmlq-x86_64-linux.tar.gz | sudo tar xz -C /usr/local/bin htmlq
+          curl -sfL https://github.com/mgdm/htmlq/releases/download/v0.4.0/htmlq-x86_64-linux.tar.gz | sudo tar xz -C /usr/local/bin htmlq
           [[- end ]]
 
       - name: Install g2

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -42,7 +42,10 @@ jobs:
       - name: Install required tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y wget jq coreutils htmlq
+          sudo apt-get install -y wget jq coreutils
+          [[- if not .DownloadRedirect ]]
+          curl -sL https://github.com/mgdm/htmlq/releases/latest/download/htmlq-x86_64-linux.tar.gz | sudo tar xz -C /usr/local/bin htmlq
+          [[- end ]]
 
       - name: Install g2
         uses: arran4/g2-action@v1.2
@@ -51,12 +54,16 @@ jobs:
         id: find_appimage
         run: |
           set -euo pipefail
+          [[- if .DownloadRedirect ]]
+          appimage_url="$(curl -sIL -o /dev/null -w '%{url_effective}' '[[ .DownloadRedirect ]]')"
+          [[- else ]]
           source_url="$(curl -sL '[[ .DownloadPageUrl ]]' | htmlq -a href 'a' | grep -iE '[[ if .DownloadMatch ]][[ .DownloadMatch ]][[ else ]]\.AppImage$[[ end ]]' | sort -V | tail -n1)"
           if [ -z "$source_url" ]; then
             echo "failed to find AppImage link" >&2
             exit 1
           fi
           appimage_url="$(curl -sIL -o /dev/null -w '%{url_effective}' "$source_url")"
+          [[- end ]]
           if [ -z "$appimage_url" ]; then
             echo "failed to resolve AppImage redirect" >&2
             exit 1


### PR DESCRIPTION
This PR addresses two issues with the current manual beeper workflow setup by porting them directly to the `overlay_workflow_builder_generator`:
1. It adds support for `DownloadRedirect` to the `InputConfig` parsing, which resolves direct AppImage URLs instead of attempting to parse HTML pages for them.
2. It fixes `htmlq` installation in the Web AppImage template. Since `htmlq` isn't available through `apt-get` natively on the runner, we now fetch the pre-compiled binary via `curl` and `tar` natively from the official `mgdm/htmlq` Github Release. We only install `htmlq` if a `DownloadRedirect` is not provided to optimize the workflow runs.

---
*PR created automatically by Jules for task [16288654113212190740](https://jules.google.com/task/16288654113212190740) started by @arran4*