### PR TITLE
feat: add Github Cmake Release workflow generator

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -184,6 +184,10 @@ func (mac *CmdConfigArgConfig) cmdConfigAdd(args []string) error {
 		if err := config.cmdConfigAddBinaryGithubReleases(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("config add: %w", err)
 		}
+	case "github-cmake-source":
+		if err := config.cmdConfigAddCmakeSourceGithubReleases(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("config add: %w", err)
+		}
 	case "web-appimage":
 		if err := config.cmdConfigAddWebAppImage(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("config add: %w", err)
@@ -328,6 +332,10 @@ func (mac *CmdConfigArgConfig) cmdConfigView(args []string) error {
 		if err := config.cmdConfigViewBinaryGithubReleases(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("config view: %w", err)
 		}
+	case "github-cmake-source":
+		if err := config.cmdConfigViewCmakeSourceGithubReleases(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("config view: %w", err)
+		}
 	case "web-appimage":
 		if err := config.cmdConfigViewWebAppImage(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("config view: %w", err)
@@ -453,6 +461,10 @@ func (mac *MainArgConfig) cmdOneshot(args []string) error {
 		if err := config.cmdOneshotGithubReleaseBinary(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("github binary: %w", err)
 		}
+	case "github-cmake-source":
+		if err := config.cmdOneshotGithubReleaseCmakeSource(fs.Args()[1:]); err != nil {
+			return fmt.Errorf("github cmake source: %w", err)
+		}
 	case "web-appimage":
 		if err := config.cmdOneshotWebAppImage(fs.Args()[1:]); err != nil {
 			return fmt.Errorf("web appimage: %w", err)
@@ -560,6 +572,108 @@ func (mac *CmdOneshotArgConfig) cmdOneshotWebAppImage(args []string) error {
 			return fmt.Errorf("url missing")
 		}
 		return arrans_overlay_workflow_builder.CmdOneshotWebAppImage(*config.PageUrl, *config.MatchExpr, valueOrDefault(config.Extension), *config.OutputDir, config.Version)
+	default:
+		log.Printf("Unknown command %s", fs.Arg(0))
+		os.Exit(-1)
+	}
+	return nil
+}
+
+type CmdConfigAddCmakeSourceGithubReleasesArgConfig struct {
+	*CmdConfigAddArgConfig
+	GithubUrl          *string
+	ConfigFile         *string
+	SelectedVersionTag *string
+	TagPrefix          *string
+}
+
+func (mac *CmdConfigAddArgConfig) cmdConfigAddCmakeSourceGithubReleases(args []string) error {
+	config := &CmdConfigAddCmakeSourceGithubReleasesArgConfig{
+		CmdConfigAddArgConfig: mac,
+	}
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	config.ConfigFile = fs.String("to", "input.config", "The input with config")
+	config.GithubUrl = fs.String("github-url", "https://github.com/owner/repo/", "The github URL to add")
+	config.SelectedVersionTag = fs.String("version-tag", "", "Version / tag override")
+	config.TagPrefix = fs.String("tag-prefix", "", "Tag prefix for app to select on and remove")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parsing flags: %w", err)
+	}
+	switch fs.Arg(0) {
+	case "":
+		if config.ConfigFile == nil || *config.ConfigFile == "" {
+			return fmt.Errorf("config file to modify argument missing")
+		}
+		if config.GithubUrl == nil || *config.GithubUrl == "" {
+			return fmt.Errorf("github URL to add is missing")
+		}
+		return arrans_overlay_workflow_builder.ConfigAddCmakeSourceGithubReleases(*config.ConfigFile, *config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix)
+	default:
+		log.Printf("Unknown command %s", fs.Arg(0))
+		log.Printf("Try %s for %s", "github-cmake-source", "Adds an configuration to a configuration file.")
+		os.Exit(-1)
+	}
+	return nil
+}
+
+type CmdConfigViewCmakeSourceGithubReleasesArgConfig struct {
+	*CmdConfigViewArgConfig
+	GithubUrl          *string
+	SelectedVersionTag *string
+	TagPrefix          *string
+}
+
+func (mac *CmdConfigViewArgConfig) cmdConfigViewCmakeSourceGithubReleases(args []string) error {
+	config := &CmdConfigViewCmakeSourceGithubReleasesArgConfig{
+		CmdConfigViewArgConfig: mac,
+	}
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	config.GithubUrl = fs.String("github-url", "https://github.com/owner/repo/", "The github URL to view")
+	config.SelectedVersionTag = fs.String("version-tag", "", "Version / tag override")
+	config.TagPrefix = fs.String("tag-prefix", "", "Tag prefix for app to select on and remove")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parsing flags: %w", err)
+	}
+	switch fs.Arg(0) {
+	case "":
+		if config.GithubUrl == nil || *config.GithubUrl == "" {
+			return fmt.Errorf("github URL to view is missing")
+		}
+		return arrans_overlay_workflow_builder.ConfigViewCmakeSourceGithubReleases(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix)
+	default:
+		log.Printf("Unknown command %s", fs.Arg(0))
+		log.Printf("Try %s for %s", "github-cmake-source", "Views an addition to a configuration file for a particular query.")
+		os.Exit(-1)
+	}
+	return nil
+}
+
+type CmdOneshotGithubReleaseCmakeSourceArgConfig struct {
+	*CmdOneshotArgConfig
+	GithubUrl          *string
+	SelectedVersionTag *string
+	TagPrefix          *string
+	OutputDir          *string
+}
+
+func (mac *CmdOneshotArgConfig) cmdOneshotGithubReleaseCmakeSource(args []string) error {
+	config := &CmdOneshotGithubReleaseCmakeSourceArgConfig{
+		CmdOneshotArgConfig: mac,
+	}
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	config.GithubUrl = fs.String("github-url", "https://github.com/owner/repo/", "The github URL to view")
+	config.SelectedVersionTag = fs.String("version-tag", "", "Version / tag override")
+	config.TagPrefix = fs.String("tag-prefix", "", "Tag prefix for app to select on and remove")
+	config.OutputDir = fs.String("output-dir", "./output", "Directory to output workflows")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parsing flags: %w", err)
+	}
+	switch fs.Arg(0) {
+	case "":
+		if config.GithubUrl == nil || *config.GithubUrl == "" {
+			return fmt.Errorf("github URL to view is missing")
+		}
+		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseCmakeSource(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version)
 	default:
 		log.Printf("Unknown command %s", fs.Arg(0))
 		os.Exit(-1)

--- a/generateGithubCmakeSourceWorkflow.go
+++ b/generateGithubCmakeSourceWorkflow.go
@@ -1,0 +1,48 @@
+package arrans_overlay_workflow_builder
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+func ConfigAddCmakeSourceGithubReleases(configFile string, githubUrl string, selectedVersionTag string, tagPrefix string) error {
+	repoName, ic, versions, tags, releaseInfo, _, err := NewInputConfigurationFromRepo(githubUrl, selectedVersionTag, tagPrefix, "", "Github Cmake Release")
+	if err != nil {
+		return err
+	}
+	_ = repoName
+	_ = versions
+	_ = tags
+	_ = releaseInfo
+
+	return AppendToConfigurationFile(configFile, ic)
+}
+
+func ConfigViewCmakeSourceGithubReleases(githubUrl string, selectedVersionTag string, tagPrefix string) error {
+	repoName, ic, versions, tags, releaseInfo, _, err := NewInputConfigurationFromRepo(githubUrl, selectedVersionTag, tagPrefix, "", "Github Cmake Release")
+	if err != nil {
+		return err
+	}
+	_ = repoName
+	_ = versions
+	_ = tags
+	_ = releaseInfo
+
+	_, err = io.WriteString(os.Stdout, ic.String())
+	return err
+}
+
+func CmdOneshotGithubReleaseCmakeSource(githubUrl string, selectedVersionTag string, tagPrefix string, outputDir string, version string) error {
+	repoName, ic, versions, tags, releaseInfo, _, err := NewInputConfigurationFromRepo(githubUrl, selectedVersionTag, tagPrefix, "", "Github Cmake Release")
+	if err != nil {
+		return err
+	}
+	_ = repoName
+	_ = versions
+	_ = tags
+	_ = releaseInfo
+
+	log.Printf("Generating from repo")
+	return GenerateGithubWorkflowsFromInputConfigs("oneshot", []*InputConfig{ic}, outputDir, version)
+}

--- a/generateGithubCmakeWorkflow.go
+++ b/generateGithubCmakeWorkflow.go
@@ -1,0 +1,30 @@
+package arrans_overlay_workflow_builder
+
+import (
+	"fmt"
+	"strings"
+)
+
+type GenerateGithubCmakeTemplateData struct {
+	*GenerateGithubWorkflowBase
+}
+
+func (ggctd *GenerateGithubCmakeTemplateData) TemplateFileName() string {
+	return "github-cmake.tmpl"
+}
+
+func (ggctd *GenerateGithubCmakeTemplateData) WorkflowName() string {
+	return fmt.Sprintf("%s/%s update", ggctd.Category, ggctd.PackageName())
+}
+
+func (ggctd *GenerateGithubCmakeTemplateData) WorkflowFileName() string {
+	return fmt.Sprintf("%s-%s-update.yaml", ggctd.Category, ggctd.PackageName())
+}
+
+func (ggctd *GenerateGithubCmakeTemplateData) PackageName() string {
+	return strings.TrimSuffix(ggctd.EbuildName, ".ebuild")
+}
+
+func (ggctd *GenerateGithubCmakeTemplateData) Metadata() (string, error) {
+	return ggctd.DefaultMetadata()
+}

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -234,6 +234,10 @@ func (ic *InputConfig) GenerateGithubWorkflow(file string, now time.Time, templa
 		data = &GenerateGithubBinaryTemplateData{
 			GenerateGithubWorkflowBase: base,
 		}
+	case "Github Cmake Release":
+		data = &GenerateGithubCmakeTemplateData{
+			GenerateGithubWorkflowBase: base,
+		}
 	default:
 		return fmt.Errorf("unknown type %s", ic.Type)
 	}

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -315,7 +315,7 @@ func (ic *InputConfig) String() string {
 		for _, programName := range programs {
 			sb.WriteString(ic.Programs[programName].String())
 		}
-	case "Github Binary Release":
+	case "Github Binary Release", "Github Cmake Release":
 		if ic.GithubProjectUrl != "" {
 			fmt.Fprintf(&sb, "GithubProjectUrl %s\n", ic.GithubProjectUrl)
 		}
@@ -592,7 +592,7 @@ func CreateSanitizeAndAppendInputConfig(parsedFields map[string][]string, parsed
 	if err != nil {
 		return nil, fmt.Errorf("on MaintainerName: %v: %w", parsedFields["MaintainerName"], err)
 	}
-	if currentConfig.Type == "Github AppImage Release" || currentConfig.Type == "Github Binary Release" {
+	if currentConfig.Type == "Github AppImage Release" || currentConfig.Type == "Github Binary Release" || currentConfig.Type == "Github Cmake Release" {
 		currentConfig.GithubOwner, currentConfig.GithubRepo, err = util.ExtractGithubOwnerRepo(currentConfig.GithubProjectUrl)
 		if err != nil {
 			return nil, fmt.Errorf("github url parser: %w", err)
@@ -628,11 +628,15 @@ func CreateSanitizeAndAppendInputConfig(parsedFields map[string][]string, parsed
 		if currentConfig.Programs == nil {
 			currentConfig.Programs = map[string]*Program{}
 		}
-	case "Github Binary Release":
+	case "Github Binary Release", "Github Cmake Release":
 		if currentConfig.EbuildName == "" {
 			currentConfig.EbuildName = currentConfig.GithubRepo
 		}
-		currentConfig.EbuildName = util.TrimSuffixes(strings.TrimSuffix(currentConfig.EbuildName, ".ebuild"), "-bin") + "-bin.ebuild"
+		if currentConfig.Type == "Github Binary Release" {
+			currentConfig.EbuildName = util.TrimSuffixes(strings.TrimSuffix(currentConfig.EbuildName, ".ebuild"), "-bin") + "-bin.ebuild"
+		} else {
+			currentConfig.EbuildName = util.TrimSuffixes(currentConfig.EbuildName, ".ebuild") + ".ebuild"
+		}
 		if currentConfig.Programs == nil {
 			currentConfig.Programs = map[string]*Program{}
 		}
@@ -692,7 +696,7 @@ func (ic *InputConfig) CreateAndSanitizeInputConfigProgram(programName string, p
 		if program.DesktopFile != "" {
 			program.DesktopFile = util.TrimSuffixes(program.DesktopFile, ".desktop") + ".desktop"
 		}
-	case "Github Binary Release":
+	case "Github Binary Release", "Github Cmake Release":
 		program.Documents, err = parseMapDoubleStringListType1(programFields["Document"])
 		if err != nil {
 			return nil, fmt.Errorf("on Document: %v: %w", programFields["Document"], err)

--- a/template_txtar_test.go
+++ b/template_txtar_test.go
@@ -91,6 +91,9 @@ func TestWorkflowTemplates(t *testing.T) {
 			case "Github Binary Release":
 				data = &GenerateGithubBinaryTemplateData{GenerateGithubWorkflowBase: base}
 				templateName = "github-binary.tmpl"
+			case "Github Cmake Release":
+				data = &GenerateGithubCmakeTemplateData{GenerateGithubWorkflowBase: base}
+				templateName = "github-cmake.tmpl"
 			case "Web AppImage":
 				data = &GenerateWebAppImageTemplateData{
 					GenerateGithubAppImageTemplateData: &GenerateGithubAppImageTemplateData{

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -1,0 +1,176 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder [[.Version]] [[.Type]] [[.ConfigFile]] [[.Now]]
+
+name: [[ .WorkflowName ]]
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '[[ .Cron ]]'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/[[ .WorkflowFileName ]]'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ecn: [[ .Category ]]
+  epn: [[ .PackageName ]]
+  description: [[ .Description | quoteStr ]]
+  homepage: [[ .Homepage  | quoteStr ]]
+  github_owner: [[ .GithubOwner ]]
+  github_repo: [[ .GithubRepo ]]
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget jq coreutils curl
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+
+          metadata_file="${ebuild_dir}/metadata.xml"
+          if [ ! -f "$metadata_file" ]; then
+            cat <<-"METADATA_EOF" > "$metadata_file"
+[[ .Metadata ]]
+METADATA_EOF
+          fi
+          g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
+
+          tags=$(gh api repos/${{ env.github_owner }}/${{ env.github_repo }}/releases --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          for tag in $tags; do
+            originalVersion="${tag#v}"
+            # shellcheck disable=SC2034
+            version="${tag#v}"
+            [[- if .WorkaroundTagPrefix ]]
+            version="${tag#[[- .WorkaroundTagPrefix ]]}"
+            [[- end ]]
+            [[- if .WorkaroundSemanticVersionWithoutV ]]
+            version="${tag}"
+            [[- end ]]
+
+            # Semantic Version format check (skip invalid tags)
+            if ! echo "$version" | egrep -q '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+              echo "$tag / $version doesn't match gentoo version regexp; skipping"
+              continue
+            fi
+
+            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
+            if [ ! -f "$ebuild_file" ]; then
+              cmake_content=$(curl -sL "https://raw.githubusercontent.com/${{ env.github_owner }}/${{ env.github_repo }}/${tag}/CMakeLists.txt")
+
+              qt6_components=$(echo "$cmake_content" | grep -i "find_package(Qt6" | tr '()' '  ' | sed 's/find_package  *Qt6//i' | tr -s ' ' '\n' | grep -ivE 'REQUIRED|COMPONENTS|CONFIG' | sort -u || true)
+              kf6_packages=$(echo "$cmake_content" | grep -i "find_package(KF6" | tr '()' '  ' | grep -iv COMPONENTS | awk '{print $2}' | grep -i "^KF6" | sed 's/KF6//i' | sort -u || true)
+              kf6_components=$(echo "$cmake_content" | grep -i "find_package(KF6" | grep -i COMPONENTS | tr '()' '  ' | sed 's/.*COMPONENTS//i' | tr -s ' ' '\n' | grep -ivE 'REQUIRED' | sort -u || true)
+
+              DEPEND=""
+              if [ -n "$qt6_components" ]; then
+                qt6_flags=$(echo "$qt6_components" | grep -ivE 'Test|Svg' | tr '\n' ',' | sed 's/,$//' | tr '[:upper:]' '[:lower:]')
+                if [ -n "$qt6_flags" ]; then
+                  DEPEND="$DEPEND\n\tdev-qt/qtbase:6[$qt6_flags]"
+                else
+                  DEPEND="$DEPEND\n\tdev-qt/qtbase:6"
+                fi
+
+                # Handling qt6 components that map to different Gentoo packages if needed
+                if echo "$qt6_components" | grep -iq "Svg"; then DEPEND="$DEPEND\n\tdev-qt/qtsvg:6"; fi
+              fi
+
+              BDEPEND="virtual/pkgconfig\n\tkde-frameworks/extra-cmake-modules:0"
+              if echo "$qt6_components" | grep -iq "Test"; then
+                 BDEPEND="$BDEPEND\n\tdev-qt/qttools:6[linguist]"
+              fi
+
+              for pkg in $kf6_packages $kf6_components; do
+                 # Basic mapping logic for KF6
+                 mapped=$(echo "$pkg" | tr '[:upper:]' '[:lower:]')
+                 DEPEND="$DEPEND\n\tkde-frameworks/k${mapped}:6"
+              done
+
+              {
+                echo "# Copyright $(date +%Y) Gentoo Authors"
+                echo "# Distributed under the terms of the GNU General Public License v2"
+                echo ""
+                echo "EAPI=8"
+                echo ""
+                echo "inherit cmake xdg"
+                echo ""
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo "SRC_URI=\"https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz -> \${P}.tar.gz\""
+                echo ""
+                echo "LICENSE=\"[[ .License ]]\""
+                echo "SLOT=\"0\""
+                echo "KEYWORDS=\"~amd64\""
+                echo "IUSE=\"debug\""
+                echo ""
+                echo "DEPEND=\""
+                echo -e "$DEPEND"
+                echo "\""
+                echo "RDEPEND=\"\${DEPEND}\""
+                echo "BDEPEND=\""
+                echo -e "$BDEPEND"
+                echo "\""
+                echo ""
+              } > "$ebuild_file"
+
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz" "${{ env.epn }}-${version}.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+            fi
+          done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          git add metadata/md5-cache/ || true
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -1,0 +1,189 @@
+-- input.config --
+Type Github Cmake Release
+GithubProjectUrl https://github.com/arran4/kjules
+Category app-misc
+EbuildName kjules
+Description A testing client
+Homepage https://github.com/arran4/kjules
+License MIT
+-- expected.yaml --
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 1.0.0 Github Cmake Release testdata/txtar/github-cmake/kllamabooks.txtar/input.config 2006-01-02 15:04:05.999999999 -0700 MST
+
+name: app-misc/kjules update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '54 10 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-misc-kjules-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  ecn: app-misc
+  epn: kjules
+  description: "A testing client"
+  homepage: "https://github.com/arran4/kjules"
+  github_owner: arran4
+  github_repo: kjules
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget jq coreutils curl
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+
+          metadata_file="${ebuild_dir}/metadata.xml"
+          if [ ! -f "$metadata_file" ]; then
+            cat <<-"METADATA_EOF" > "$metadata_file"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>gentoo@arran4.com</email>
+		<name>Arran Ubels</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">arran4/kjules</remote-id>
+	</upstream>
+</pkgmetadata>
+METADATA_EOF
+          fi
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:arran4/kjules" "$metadata_file"
+
+          tags=$(gh api repos/${{ env.github_owner }}/${{ env.github_repo }}/releases --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          for tag in $tags; do
+            originalVersion="${tag#v}"
+            # shellcheck disable=SC2034
+            version="${tag#v}"
+
+            # Semantic Version format check (skip invalid tags)
+            if ! echo "$version" | egrep -q '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+              echo "$tag / $version doesn't match gentoo version regexp; skipping"
+              continue
+            fi
+
+            ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild"
+            if [ ! -f "$ebuild_file" ]; then
+              cmake_content=$(curl -sL "https://raw.githubusercontent.com/${{ env.github_owner }}/${{ env.github_repo }}/${tag}/CMakeLists.txt")
+
+              qt6_components=$(echo "$cmake_content" | grep -i "find_package(Qt6" | tr '()' '  ' | sed 's/find_package  *Qt6//i' | tr -s ' ' '\n' | grep -ivE 'REQUIRED|COMPONENTS|CONFIG' | sort -u || true)
+              kf6_packages=$(echo "$cmake_content" | grep -i "find_package(KF6" | tr '()' '  ' | grep -iv COMPONENTS | awk '{print $2}' | grep -i "^KF6" | sed 's/KF6//i' | sort -u || true)
+              kf6_components=$(echo "$cmake_content" | grep -i "find_package(KF6" | grep -i COMPONENTS | tr '()' '  ' | sed 's/.*COMPONENTS//i' | tr -s ' ' '\n' | grep -ivE 'REQUIRED' | sort -u || true)
+
+              DEPEND=""
+              if [ -n "$qt6_components" ]; then
+                qt6_flags=$(echo "$qt6_components" | grep -ivE 'Test|Svg' | tr '\n' ',' | sed 's/,$//' | tr '[:upper:]' '[:lower:]')
+                if [ -n "$qt6_flags" ]; then
+                  DEPEND="$DEPEND\n\tdev-qt/qtbase:6[$qt6_flags]"
+                else
+                  DEPEND="$DEPEND\n\tdev-qt/qtbase:6"
+                fi
+
+                # Handling qt6 components that map to different Gentoo packages if needed
+                if echo "$qt6_components" | grep -iq "Svg"; then DEPEND="$DEPEND\n\tdev-qt/qtsvg:6"; fi
+              fi
+
+              BDEPEND="virtual/pkgconfig\n\tkde-frameworks/extra-cmake-modules:0"
+              if echo "$qt6_components" | grep -iq "Test"; then
+                 BDEPEND="$BDEPEND\n\tdev-qt/qttools:6[linguist]"
+              fi
+
+              for pkg in $kf6_packages $kf6_components; do
+                 # Basic mapping logic for KF6
+                 mapped=$(echo "$pkg" | tr '[:upper:]' '[:lower:]')
+                 DEPEND="$DEPEND\n\tkde-frameworks/k${mapped}:6"
+              done
+
+              {
+                echo "# Copyright $(date +%Y) Gentoo Authors"
+                echo "# Distributed under the terms of the GNU General Public License v2"
+                echo ""
+                echo "EAPI=8"
+                echo ""
+                echo "inherit cmake xdg"
+                echo ""
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo "SRC_URI=\"https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz -> \${P}.tar.gz\""
+                echo ""
+                echo "LICENSE=\"MIT\""
+                echo "SLOT=\"0\""
+                echo "KEYWORDS=\"~amd64\""
+                echo "IUSE=\"debug\""
+                echo ""
+                echo "DEPEND=\""
+                echo -e "$DEPEND"
+                echo "\""
+                echo "RDEPEND=\"\${DEPEND}\""
+                echo "BDEPEND=\""
+                echo -e "$BDEPEND"
+                echo "\""
+                echo ""
+              } > "$ebuild_file"
+
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz" "${{ env.epn }}-${version}.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+            fi
+          done
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint .'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          git add metadata/md5-cache/ || true
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git p\ull --rebase &&
+            git p\ush
+          fi || true
+        if: steps.process_releases.outputs.generated_tag


### PR DESCRIPTION
This PR adds a new config type `Github Cmake Release` (and CLI command `github-cmake-source`) to the generator to support automatically creating ebuild workflows for standard CMake projects hosted on GitHub, with a focus on automatic Qt6 and KF6 dependency extraction.

It adds:
- A new `Github Cmake Release` config type to `inputconfig.go`
- `github-cmake-source` CLI logic to `cmd/generate/main.go`
- `generateGithubCmakeWorkflow.go` to provide template bindings
- A new `templates/github-cmake.tmpl` that dynamically fetches `CMakeLists.txt` per release to infer the appropriate Qt6/KF6 ebuild dependencies.

---
*PR created automatically by Jules for task [17615774917971548194](https://jules.google.com/task/17615774917971548194) started by @arran4*