### PR TITLE
Fix HOMEPAGE Field Generation in Ebuild Templates

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -21,7 +21,6 @@ env:
   ecn: [[ .Category ]]
   epn: [[ .PackageName ]]
   description: [[ .Description | quoteStr ]]
-  homepage: [[ .Homepage  | quoteStr ]]
   github_owner: [[ .GithubOwner ]]
   github_repo: [[ .GithubRepo ]]
   keywords: [[ .MaskedKeywords ]]
@@ -113,7 +112,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="[[ .Homepage ]]"'
                 echo 'LICENSE="[[ .License ]]"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -21,7 +21,6 @@ env:
   ecn: [[ .Category ]]
   epn: [[ .PackageName ]]
   description: [[ .Description | quoteStr ]]
-  homepage: [[ .Homepage  | quoteStr ]]
   github_owner: [[ .GithubOwner ]]
   github_repo: [[ .GithubRepo ]]
   keywords: [[ .MaskedKeywords ]]
@@ -117,7 +116,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="[[ .Homepage ]]"'
                 echo 'SRC_URI="'
 [[- range $i, $externalResource := .ExternalResources ]]
                 echo "	[[range $i, $uf := .MustHaveUseFlags]][[ $uf | UseFlagSafe ]]? ( [[end]][[range $i, $uf := .MustntHaveUseFlags]]![[ $uf | UseFlagSafe ]]? ( [[end]] https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/[[- if $.WorkaroundSemanticVersionWithoutV ]]${originalVersion}[[ else ]][[- $.WorkaroundTagPrefix ]]v${originalVersion}[[ end ]]/[[- if $.WorkaroundSemanticVersionPrereleaseHack1 ]][[ $externalResource.ReleaseFilename | ebuildvardoublequotedSemanticVersionPrereleaseHack1 | replace "\\${PV}" "${originalVersion}" ]][[- else ]][[ $externalResource.ReleaseFilename | ebuildvardoublequoted | replace "\\${PV}" "${originalVersion}" ]][[- end ]] -> \${P}-[[ $externalResource.ReleaseFilename  | ebuildvardoublequoted ]] [[range $i, $uf := .MustHaveUseFlags]] ) [[end]][[range $i, $uf := .MustntHaveUseFlags]] ) [[ end ]] "

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -22,7 +22,6 @@ env:
   ecn: [[ .Category ]]
   epn: [[ .PackageName ]]
   description: [[ .Description | quoteStr ]]
-  homepage: [[ .Homepage  | quoteStr ]]
   github_owner: [[ .GithubOwner ]]
   github_repo: [[ .GithubRepo ]]
 
@@ -118,7 +117,7 @@ jobs:
                 echo "inherit cmake xdg"
                 echo ""
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="[[ .Homepage ]]"'
                 echo "SRC_URI=\"https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz -> \${P}.tar.gz\""
                 echo ""
                 echo "LICENSE=\"[[ .License ]]\""

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -17,7 +17,6 @@ env:
   ecn: [[ .Category ]]
   epn: [[ .PackageName ]]
   description: [[ .Description | quoteStr ]]
-  homepage: [[ .Homepage  | quoteStr ]]
   keywords: [[ .MaskedKeywords ]]
   workflow_filename: [[ .WorkflowFileName ]]
   [[- range $pname, $prog := .Programs ]]
@@ -92,7 +91,7 @@ jobs:
               echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
               echo 'EAPI=8'
               echo "DESCRIPTION=\"${{ env.description }}\""
-              echo "HOMEPAGE=\"${{ env.homepage }}\""
+              echo 'HOMEPAGE="[[ .Homepage ]]"'
               echo 'LICENSE="[[ .License ]]"'
               echo 'SLOT="0"'
               echo 'KEYWORDS="${{ env.keywords }}"'

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -21,7 +21,6 @@ env:
   ecn: [[ .Category ]]
   epn: [[ .PackageName ]]
   description: [[ .Description | quoteStr ]]
-  homepage: [[ .Homepage  | quoteStr ]]
   github_owner: [[ .GithubOwner ]]
   github_repo: [[ .GithubRepo ]]
   keywords: [[ .MaskedKeywords ]]
@@ -119,7 +118,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="[[ .Homepage ]]"'
                 echo 'SRC_URI="'
 [[- range $i, $externalResource := .ExternalResources ]]
                 echo "	[[range $i, $uf := .MustHaveUseFlags]][[ $uf | UseFlagSafe ]]? ( [[end]][[range $i, $uf := .MustntHaveUseFlags]]![[ $uf | UseFlagSafe ]]? ( [[end]] [[ $.DownloadBaseUrl ]][[- if $.WorkaroundSemanticVersionPrereleaseHack1 ]][[ $externalResource.ReleaseFilename | ebuildvardoublequotedSemanticVersionPrereleaseHack1 | replace "\\${PV}" "${originalVersion}" ]][[- else ]][[ $externalResource.ReleaseFilename | ebuildvardoublequoted | replace "\\${PV}" "${originalVersion}" ]][[- end ]] -> \${P}-[[ $externalResource.ReleaseFilename  | ebuildvardoublequoted ]] [[range $i, $uf := .MustHaveUseFlags]] ) [[end]][[range $i, $uf := .MustntHaveUseFlags]] ) [[ end ]] "

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -43,7 +43,6 @@ env:
   ecn: net-misc
   epn: rustdesk-appimage
   description: "Open-source remote desktop application for self-hosting"
-  homepage: "https://rustdesk.com/"
   github_owner: rustdesk
   github_repo: rustdesk
   keywords: ~amd64 ~arm64
@@ -104,7 +103,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://rustdesk.com/"'
                 echo 'LICENSE="AGPL-3"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -42,7 +42,6 @@ env:
   ecn: net-misc
   epn: rustdesk-appimage
   description: "Open-source remote desktop application for self-hosting"
-  homepage: "https://rustdesk.com/"
   github_owner: rustdesk
   github_repo: rustdesk
   keywords: ~amd64 ~arm64
@@ -103,7 +102,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://rustdesk.com/"'
                 echo 'LICENSE="AGPL-3"'
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -34,7 +34,6 @@ env:
   ecn: app-admin
   epn: k9s-bin
   description: "Kubernetes CLI To Manage Your Clusters In Style!"
-  homepage: "https://k9scli.io/"
   github_owner: derailed
   github_repo: k9s
   keywords: ~amd64
@@ -98,7 +97,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://k9scli.io/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v${originalVersion}/\${PV} -> \${P}-k9s_Linux_amd64.tar.gz  )  "
                 echo '"'

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -38,7 +38,6 @@ env:
   ecn: app-misc
   epn: tool-bin
   description: "An example tool for testing"
-  homepage: "https://example.com/"
   github_owner: example
   github_repo: tool
   keywords: ~amd64
@@ -101,7 +100,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://example.com/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/v${originalVersion}/\${PV} -> \${P}-tool-${tag}-amd64  )  "
                 echo '"'

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -34,7 +34,6 @@ env:
   ecn: app-misc
   epn: kjules
   description: "A testing client"
-  homepage: "https://github.com/arran4/kjules"
   github_owner: arran4
   github_repo: kjules
 
@@ -111,7 +110,7 @@ jobs:
                 echo "inherit cmake xdg"
                 echo ""
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://github.com/arran4/kjules"'
                 echo "SRC_URI=\"https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz -> \${P}.tar.gz\""
                 echo ""
                 echo "LICENSE=\"MIT\""

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -34,7 +34,6 @@ env:
   ecn: app-misc
   epn: kjules
   description: "A testing client"
-  homepage: "https://github.com/arran4/kjules"
   github_owner: arran4
   github_repo: kjules
 
@@ -111,7 +110,7 @@ jobs:
                 echo "inherit cmake xdg"
                 echo ""
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://github.com/arran4/kjules"'
                 echo "SRC_URI=\"https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/archive/refs/tags/${tag}.tar.gz -> \${P}.tar.gz\""
                 echo ""
                 echo "LICENSE=\"MIT\""

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -38,7 +38,6 @@ env:
   ecn: net-im
   epn: example-appimage
   description: "Example self-contained desktop client"
-  homepage: "https://www.example.com/"
   keywords: ~amd64
   workflow_filename: net-im-example-appimage-update.yaml
   example_desktop_file: 'example.desktop'
@@ -103,7 +102,7 @@ jobs:
               echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
               echo 'EAPI=8'
               echo "DESCRIPTION=\"${{ env.description }}\""
-              echo "HOMEPAGE=\"${{ env.homepage }}\""
+              echo 'HOMEPAGE="https://www.example.com/"'
               echo 'LICENSE="MIT"'
               echo 'SLOT="0"'
               echo 'KEYWORDS="${{ env.keywords }}"'

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -37,7 +37,6 @@ env:
   ecn: net-im
   epn: example-appimage
   description: "Example self-contained desktop client"
-  homepage: "https://www.example.com/"
   keywords: ~amd64
   workflow_filename: net-im-example-appimage-update.yaml
   example_desktop_file: 'example.desktop'
@@ -102,7 +101,7 @@ jobs:
               echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
               echo 'EAPI=8'
               echo "DESCRIPTION=\"${{ env.description }}\""
-              echo "HOMEPAGE=\"${{ env.homepage }}\""
+              echo 'HOMEPAGE="https://www.example.com/"'
               echo 'LICENSE="MIT"'
               echo 'SLOT="0"'
               echo 'KEYWORDS="${{ env.keywords }}"'

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -40,7 +40,6 @@ env:
   ecn: app-admin
   epn: google-cloud-sdk-bin
   description: "Google Cloud SDK"
-  homepage: "https://cloud.google.com/sdk/"
   github_owner:
   github_repo: google-cloud-sdk
   keywords: ~amd64 ~arm64 ~x86
@@ -114,7 +113,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://cloud.google.com/sdk/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/\${PV} -> \${P}-google-cloud-cli-\${PV}-linux-x86_64.tar.gz  )  "
                 echo "	arm64? (  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/\${PV} -> \${P}-google-cloud-cli-\${PV}-linux-arm.tar.gz  )  "

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -38,7 +38,6 @@ env:
   ecn: app-admin
   epn: google-cloud-sdk-bin
   description: "Google Cloud SDK"
-  homepage: "https://cloud.google.com/sdk/"
   github_owner:
   github_repo: google-cloud-sdk
   keywords: ~amd64 ~arm64 ~x86
@@ -112,7 +111,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://cloud.google.com/sdk/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/\${PV} -> \${P}-google-cloud-cli-\${PV}-linux-x86_64.tar.gz  )  "
                 echo "	arm64? (  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/\${PV} -> \${P}-google-cloud-cli-\${PV}-linux-arm.tar.gz  )  "

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -39,7 +39,6 @@ env:
   ecn: app-admin
   epn: google-cloud-sdk-bin
   description: "Google Cloud SDK"
-  homepage: "https://cloud.google.com/sdk/"
   github_owner:
   github_repo: google-cloud-sdk
   keywords: ~amd64 ~arm64 ~x86
@@ -113,7 +112,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://cloud.google.com/sdk/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/\${PV} -> \${P}-google-cloud-cli-\${PV}-linux-x86_64.tar.gz  )  "
                 echo "	arm64? (  https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/\${PV} -> \${P}-google-cloud-cli-\${PV}-linux-arm.tar.gz  )  "

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -43,7 +43,6 @@ env:
   ecn: net-misc
   epn: rustdesk-bin
   description: "Remote desktop software"
-  homepage: "https://rustdesk.com/"
   github_owner: rustdesk
   github_repo: rustdesk
   keywords: ~amd64
@@ -104,7 +103,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://rustdesk.com/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${originalVersion}/\${PV} -> \${P}-rustdesk-\${PV}-x86_64.tar.gz  )  "
                 echo '"'

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -42,7 +42,6 @@ env:
   ecn: net-misc
   epn: rustdesk-bin
   description: "Remote desktop software"
-  homepage: "https://rustdesk.com/"
   github_owner: rustdesk
   github_repo: rustdesk
   keywords: ~amd64
@@ -103,7 +102,7 @@ jobs:
                 echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
                 echo 'EAPI=8'
                 echo "DESCRIPTION=\"${{ env.description }}\""
-                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'HOMEPAGE="https://rustdesk.com/"'
                 echo 'SRC_URI="'
                 echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${originalVersion}/\${PV} -> \${P}-rustdesk-\${PV}-x86_64.tar.gz  )  "
                 echo '"'


### PR DESCRIPTION
This PR implements a native Go template injection for the HOMEPAGE field in the workflow templates (`github-appimage`, `github-binary`, `github-cmake`, `web-appimage`, `web-binary`). Previously, the `homepage` was routed through a GitHub Actions `env:` variable which required `sed` manual injection to properly map it in ebuilds.

By using `[[ .Homepage ]]` directly within the ebuild script generation block, the code is simplified and runtime issues with GitHub Action variable escaping are avoided. Test text archives in `testdata` have been updated accordingly via `go test -update-txtar ./...`.

unblocks: https://github.com/arran4/arrans_overlay/pull/676

---
*PR created automatically by Jules for task [10036669404365621385](https://jules.google.com/task/10036669404365621385) started by @arran4*