### PR TITLE
Fix support for multiple binaries from same archive in Github Binary Release

### DIFF
--- a/generateGithubBinaryWorkflow.go
+++ b/generateGithubBinaryWorkflow.go
@@ -3,13 +3,14 @@ package arrans_overlay_workflow_builder
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/arran4/g2"
-	"github.com/stoewer/go-strcase"
 	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/arran4/g2"
+	"github.com/stoewer/go-strcase"
 )
 
 type GenerateGithubBinaryTemplateData struct {
@@ -523,7 +524,17 @@ func (ggbtd *GenerateGithubBinaryTemplateData) ExternalResources() []*ExternalRe
 				MustHaveUseFlags:   ggbtd.GetMustHaveUseFlags(programName, kwWithFlags),
 				MustntHaveUseFlags: ggbtd.GetMustntHaveUseFlags(programName, kwWithFlags),
 			}
-			m[rfn[0]] = e
+			if existing, ok := m[rfn[0]]; ok {
+				existing.MustHaveUseFlags = append(existing.MustHaveUseFlags, ggbtd.GetMustHaveUseFlags(programName, kwWithFlags)...)
+				slices.Sort(existing.MustHaveUseFlags)
+				existing.MustHaveUseFlags = slices.Compact(existing.MustHaveUseFlags)
+
+				existing.MustntHaveUseFlags = append(existing.MustntHaveUseFlags, ggbtd.GetMustntHaveUseFlags(programName, kwWithFlags)...)
+				slices.Sort(existing.MustntHaveUseFlags)
+				existing.MustntHaveUseFlags = slices.Compact(existing.MustntHaveUseFlags)
+			} else {
+				m[rfn[0]] = e
+			}
 		}
 	}
 	result := make([]*ExternalResourceKeywordExtended, 0, len(ggbtd.Programs))


### PR DESCRIPTION
The user wants to support specifying multiple binaries from the same archive for a single `Github Binary Release`.
For example, `ast-grep` requires installing both `ast-grep` and `sg` from the same zip file. In such case, it will appear as two programs in config file pointing to same zip file release name. Right now, this doesn't work correctly because the `SRC_URI` and unpack logic gets duplicated for each program sharing same archive url.

We found that `ExternalResources` in `GenerateGithubBinaryTemplateData` collects the release files by mapping them using the release file name as key. However, when we encounter multiple binaries with the same archive name, it overrides the `ExternalResourceKeywordExtended` and loses the `MustHaveUseFlags`/`MustntHaveUseFlags` of the previous program.

I updated `ExternalResources` method in `generateGithubBinaryWorkflow.go` to merge the `MustHaveUseFlags` and `MustntHaveUseFlags` for the same release filename. We use `slices.Compact(slices.Sort(...))` to remove duplicates.

---
*PR created automatically by Jules for task [78535835385983588](https://jules.google.com/task/78535835385983588) started by @arran4*