### PR TITLE
Fix variable regression in github and web binary workflows

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -35,7 +35,7 @@ env:
   [[- if gt (len $binary) 2 ]]
   [[ join (filterEmpty $pname "appimage_archived_name" $keyword) "_" ]]: '[[ index $binary 1 ]]'
   [[ end ]]
-  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | ebuildvardoublequoted ]]'
+  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | actionvardoublequoted ]]'
   [[ end ]]
   [[ end ]]
 

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -35,7 +35,7 @@ env:
   [[- if gt (len $binary) 2 ]]
   [[ join (filterEmpty $pname "binary_archived_name" $keyword) "_" ]]: '[[ index $binary 1 ]]'
   [[ end ]]
-  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | ebuildvardoublequoted ]]'
+  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | actionvardoublequoted ]]'
   [[ end ]]
   [[ end ]]
 

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -35,7 +35,7 @@ env:
   [[- if gt (len $binary) 2 ]]
   [[ join (filterEmpty $pname "binary_archived_name" $keyword) "_" ]]: '[[ index $binary 1 ]]'
   [[ end ]]
-  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | ebuildvardoublequoted ]]'
+  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | actionvardoublequoted ]]'
   [[ end ]]
   [[ end ]]
 

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -46,7 +46,7 @@ env:
   workflow_filename: app-misc-example-appimage-update.yaml
   example_desktop_file: 'example.desktop'
   example_appimage_installed_name: 'example'
-  example_release_name_amd64: 'example-linux-x86_64-\${PV}.AppImage'
+  example_release_name_amd64: 'example-linux-x86_64-${version}.AppImage'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -44,7 +44,7 @@ env:
   keywords: ~amd64
   workflow_filename: app-misc-example-bin-update.yaml
   example_binary_installed_name: 'example'
-  example_release_name_amd64: 'example-linux-x86_64-\${PV}.tar.gz'
+  example_release_name_amd64: 'example-linux-x86_64-${version}.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -47,11 +47,11 @@ env:
   workflow_filename: app-admin-google-cloud-sdk-bin-update.yaml
   google-cloud-cli_binary_installed_name: 'gcloud'
   google-cloud-cli_binary_archived_name_amd64: 'gcloud'
-  google-cloud-cli_release_name_amd64: 'google-cloud-cli-\${PV}-linux-x86_64.tar.gz'
+  google-cloud-cli_release_name_amd64: 'google-cloud-cli-${version}-linux-x86_64.tar.gz'
   google-cloud-cli_binary_archived_name_arm64: 'gcloud'
-  google-cloud-cli_release_name_arm64: 'google-cloud-cli-\${PV}-linux-arm.tar.gz'
+  google-cloud-cli_release_name_arm64: 'google-cloud-cli-${version}-linux-arm.tar.gz'
   google-cloud-cli_binary_archived_name_x86: 'gcloud'
-  google-cloud-cli_release_name_x86: 'google-cloud-cli-\${PV}-linux-x86.tar.gz'
+  google-cloud-cli_release_name_x86: 'google-cloud-cli-${version}-linux-x86.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -41,7 +41,7 @@ env:
   keywords: ~amd64
   workflow_filename: app-misc-example-bin-update.yaml
   example_binary_installed_name: 'example'
-  example_release_name_amd64: 'example-\${PV}.tar.gz'
+  example_release_name_amd64: 'example-${version}.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -45,11 +45,11 @@ env:
   workflow_filename: app-admin-google-cloud-sdk-bin-update.yaml
   google-cloud-cli_binary_installed_name: 'gcloud'
   google-cloud-cli_binary_archived_name_amd64: 'gcloud'
-  google-cloud-cli_release_name_amd64: 'google-cloud-cli-\${PV}-linux-x86_64.tar.gz'
+  google-cloud-cli_release_name_amd64: 'google-cloud-cli-${version}-linux-x86_64.tar.gz'
   google-cloud-cli_binary_archived_name_arm64: 'gcloud'
-  google-cloud-cli_release_name_arm64: 'google-cloud-cli-\${PV}-linux-arm.tar.gz'
+  google-cloud-cli_release_name_arm64: 'google-cloud-cli-${version}-linux-arm.tar.gz'
   google-cloud-cli_binary_archived_name_x86: 'gcloud'
-  google-cloud-cli_release_name_x86: 'google-cloud-cli-\${PV}-linux-x86.tar.gz'
+  google-cloud-cli_release_name_x86: 'google-cloud-cli-${version}-linux-x86.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -46,11 +46,11 @@ env:
   workflow_filename: app-admin-google-cloud-sdk-bin-update.yaml
   google-cloud-cli_binary_installed_name: 'gcloud'
   google-cloud-cli_binary_archived_name_amd64: 'gcloud'
-  google-cloud-cli_release_name_amd64: 'google-cloud-cli-\${PV}-linux-x86_64.tar.gz'
+  google-cloud-cli_release_name_amd64: 'google-cloud-cli-${version}-linux-x86_64.tar.gz'
   google-cloud-cli_binary_archived_name_arm64: 'gcloud'
-  google-cloud-cli_release_name_arm64: 'google-cloud-cli-\${PV}-linux-arm.tar.gz'
+  google-cloud-cli_release_name_arm64: 'google-cloud-cli-${version}-linux-arm.tar.gz'
   google-cloud-cli_binary_archived_name_x86: 'gcloud'
-  google-cloud-cli_release_name_x86: 'google-cloud-cli-\${PV}-linux-x86.tar.gz'
+  google-cloud-cli_release_name_x86: 'google-cloud-cli-${version}-linux-x86.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -50,7 +50,7 @@ env:
   workflow_filename: net-misc-rustdesk-bin-update.yaml
   rustdesk_binary_installed_name: 'rustdesk'
   rustdesk_binary_archived_name_amd64: 'rustdesk'
-  rustdesk_release_name_amd64: 'rustdesk-\${PV}-x86_64.tar.gz'
+  rustdesk_release_name_amd64: 'rustdesk-${version}-x86_64.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -49,7 +49,7 @@ env:
   workflow_filename: net-misc-rustdesk-bin-update.yaml
   rustdesk_binary_installed_name: 'rustdesk'
   rustdesk_binary_archived_name_amd64: 'rustdesk'
-  rustdesk_release_name_amd64: 'rustdesk-\${PV}-x86_64.tar.gz'
+  rustdesk_release_name_amd64: 'rustdesk-${version}-x86_64.tar.gz'
 
 jobs:
   check-and-create-ebuild:


### PR DESCRIPTION
Fix variable regression in github and web binary workflows

The variable mapping for binary release names inside the generated GitHub Actions `env` block was erroneously using `ebuildvardoublequoted`, which caused `${TAG}` to be formatted as `\${PV}`. This commit replaces it with `actionvardoublequoted`, restoring correct mapping to `${version}` or `${tag}` so the bash loops inside the GitHub Action runner can correctly evaluate the release name string without evaluating to an empty value. Tests have been updated.

---
*PR created automatically by Jules for task [737745998464698607](https://jules.google.com/task/737745998464698607) started by @arran4*