### PR TITLE
Fix: Remove automatic staging of untracked md5-cache directory

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -34,16 +34,16 @@ func main() {
 		Commit:  commit,
 		Date:    date,
 	}
-	var globalCommitMd5Cache bool
+	var globalGenerateMd5Cache bool
 	// A workaround for global flags being parsed before the command is parsed
 	for i, arg := range os.Args {
-		if arg == "--commit-md5-cache" || arg == "-commit-md5-cache" {
-			globalCommitMd5Cache = true
+		if arg == "--generate-md5-cache" || arg == "-generate-md5-cache" {
+			globalGenerateMd5Cache = true
 			os.Args = append(os.Args[:i], os.Args[i+1:]...)
 			break
 		}
 	}
-	arrans_overlay_workflow_builder.CommitMd5CacheGlobal = globalCommitMd5Cache
+	arrans_overlay_workflow_builder.GenerateMd5CacheGlobal = globalGenerateMd5Cache
 
 	if err := fs.Parse(os.Args); err != nil {
 		log.Printf("Flag parse error: %s", err)

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -34,6 +34,17 @@ func main() {
 		Commit:  commit,
 		Date:    date,
 	}
+	var globalCommitMd5Cache bool
+	// A workaround for global flags being parsed before the command is parsed
+	for i, arg := range os.Args {
+		if arg == "--commit-md5-cache" || arg == "-commit-md5-cache" {
+			globalCommitMd5Cache = true
+			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+			break
+		}
+	}
+	arrans_overlay_workflow_builder.CommitMd5CacheGlobal = globalCommitMd5Cache
+
 	if err := fs.Parse(os.Args); err != nil {
 		log.Printf("Flag parse error: %s", err)
 		os.Exit(-1)

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -344,3 +344,7 @@ func (b *GenerateGithubWorkflowBase) WorkaroundVersionReplacement() string {
 func (b *GenerateGithubWorkflowBase) WorkaroundGentooVersionRegularExpression() string {
 	return b.InputConfig.WorkaroundGentooVersionRegularExpression()
 }
+
+func (b *GenerateGithubWorkflowBase) WorkaroundCommitMd5Cache() bool {
+	return b.InputConfig.WorkaroundCommitMd5Cache()
+}

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -345,6 +345,6 @@ func (b *GenerateGithubWorkflowBase) WorkaroundGentooVersionRegularExpression() 
 	return b.InputConfig.WorkaroundGentooVersionRegularExpression()
 }
 
-func (b *GenerateGithubWorkflowBase) WorkaroundCommitMd5Cache() bool {
-	return b.InputConfig.WorkaroundCommitMd5Cache()
+func (b *GenerateGithubWorkflowBase) FeatureGenerateMd5Cache() bool {
+	return b.InputConfig.FeatureGenerateMd5Cache()
 }

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -791,7 +791,7 @@ func (ic *InputConfig) WorkaroundSemanticVersionWithoutV() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Semantic Version Without V"]
-	return ok || CommitMd5CacheGlobal
+	return ok
 }
 
 func (ic *InputConfig) WorkaroundSemanticVersionPrereleaseHack1() bool {
@@ -799,7 +799,7 @@ func (ic *InputConfig) WorkaroundSemanticVersionPrereleaseHack1() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Semantic Version Prerelease Hack 1"]
-	return ok || CommitMd5CacheGlobal
+	return ok
 }
 
 func (ic *InputConfig) WorkaroundCheckAssetSize() bool {
@@ -807,7 +807,7 @@ func (ic *InputConfig) WorkaroundCheckAssetSize() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Check Asset Size"]
-	return ok || CommitMd5CacheGlobal
+	return ok
 }
 
 func (ic *InputConfig) WorkaroundTagPrefix() string {

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -232,6 +232,7 @@ type InputConfig struct {
 	License          string
 	MaintainerEmail  string
 	MaintainerName   string
+	Features         map[string]string
 	Workarounds      map[string]string
 	Programs         map[string]*Program
 	IUse             []string
@@ -329,6 +330,15 @@ func (ic *InputConfig) String() string {
 		if ic.MaintainerName != "" {
 			fmt.Fprintf(&sb, "MaintainerName %s\n", ic.MaintainerName)
 		}
+		features := ic.FeatureString()
+		for _, feature := range features {
+			if len(ic.Features[feature]) == 0 {
+				fmt.Fprintf(&sb, "Feature %s\n", feature)
+			} else {
+				fmt.Fprintf(&sb, "Feature %s => %s\n", feature, ic.Features[feature])
+			}
+		}
+
 		workarounds := ic.WorkaroundString()
 		for _, workaround := range workarounds {
 			if len(ic.Workarounds[workaround]) == 0 {
@@ -378,6 +388,15 @@ func (ic *InputConfig) String() string {
 		if ic.MaintainerName != "" {
 			fmt.Fprintf(&sb, "MaintainerName %s\n", ic.MaintainerName)
 		}
+		features := ic.FeatureString()
+		for _, feature := range features {
+			if len(ic.Features[feature]) == 0 {
+				fmt.Fprintf(&sb, "Feature %s\n", feature)
+			} else {
+				fmt.Fprintf(&sb, "Feature %s => %s\n", feature, ic.Features[feature])
+			}
+		}
+
 		workarounds := ic.WorkaroundString()
 		for _, workaround := range workarounds {
 			if len(ic.Workarounds[workaround]) == 0 {
@@ -404,6 +423,15 @@ func (ic *InputConfig) ProgramsString() []string {
 	}
 	sort.Strings(programs)
 	return programs
+}
+
+func (ic *InputConfig) FeatureString() []string {
+	var features []string
+	for key := range ic.Features {
+		features = append(features, key)
+	}
+	sort.Strings(features)
+	return features
 }
 
 func (ic *InputConfig) WorkaroundString() []string {
@@ -474,6 +502,7 @@ func ParseInputConfigReader(file io.Reader) ([]*InputConfig, error) {
 				"Document":              nil,
 				"ShellCompletionScript": nil,
 				"Dependencies":          nil,
+				"Feature":               nil,
 				"Workaround":            nil,
 				"Binary":                nil,
 				"IUse":                  nil,
@@ -658,6 +687,11 @@ func CreateSanitizeAndAppendInputConfig(parsedFields map[string][]string, parsed
 			return nil, fmt.Errorf("github url parser: %w", err)
 		}
 	}
+	currentConfig.Features, err = parseOptionalMapType1(parsedFields["Feature"])
+	if err != nil {
+		return nil, fmt.Errorf("on Features: %v: %w", parsedFields["Feature"], err)
+	}
+
 	currentConfig.Workarounds, err = parseOptionalMapType1(parsedFields["Workaround"])
 	if err != nil {
 		return nil, fmt.Errorf("on Workarounds: %v: %w", parsedFields["Workaround"], err)
@@ -1029,6 +1063,7 @@ func NewInputConfigurationFromRepo(gitRepo, tagOverride, tagPrefix, ebuildSuffix
 		Homepage:    util.StringOrDefault(repo.Homepage, ""),
 		GithubRepo:  repoName,
 		GithubOwner: ownerName,
+		Features: map[string]string{},
 		Workarounds: map[string]string{},
 		Programs:    map[string]*Program{},
 		License:     util.StringOrDefault(licenseName, "unknown"),
@@ -1135,12 +1170,12 @@ func (ic *InputConfig) WorkaroundGentooVersionRegularExpression() string {
 	return ic.Workarounds["Gentoo Version Regular Expression"]
 }
 
-func (ic *InputConfig) WorkaroundCommitMd5Cache() bool {
-	if ic.Workarounds == nil {
+func (ic *InputConfig) FeatureGenerateMd5Cache() bool {
+	if ic.Features == nil {
 		return false
 	}
-	_, ok := ic.Workarounds["Commit Md5 Cache"]
-	return ok || CommitMd5CacheGlobal
+	_, ok := ic.Features["Generate Md5 Cache"]
+	return ok || GenerateMd5CacheGlobal
 }
 
-var CommitMd5CacheGlobal = false
+var GenerateMd5CacheGlobal = false

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -1134,3 +1134,11 @@ func (ic *InputConfig) WorkaroundGentooVersionRegularExpression() string {
 	}
 	return ic.Workarounds["Gentoo Version Regular Expression"]
 }
+
+func (ic *InputConfig) WorkaroundCommitMd5Cache() bool {
+	if ic.Workarounds == nil {
+		return false
+	}
+	_, ok := ic.Workarounds["Commit Md5 Cache"]
+	return ok
+}

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -791,7 +791,7 @@ func (ic *InputConfig) WorkaroundSemanticVersionWithoutV() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Semantic Version Without V"]
-	return ok
+	return ok || CommitMd5CacheGlobal
 }
 
 func (ic *InputConfig) WorkaroundSemanticVersionPrereleaseHack1() bool {
@@ -799,7 +799,7 @@ func (ic *InputConfig) WorkaroundSemanticVersionPrereleaseHack1() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Semantic Version Prerelease Hack 1"]
-	return ok
+	return ok || CommitMd5CacheGlobal
 }
 
 func (ic *InputConfig) WorkaroundCheckAssetSize() bool {
@@ -807,7 +807,7 @@ func (ic *InputConfig) WorkaroundCheckAssetSize() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Check Asset Size"]
-	return ok
+	return ok || CommitMd5CacheGlobal
 }
 
 func (ic *InputConfig) WorkaroundTagPrefix() string {
@@ -1140,5 +1140,7 @@ func (ic *InputConfig) WorkaroundCommitMd5Cache() bool {
 		return false
 	}
 	_, ok := ic.Workarounds["Commit Md5 Cache"]
-	return ok
+	return ok || CommitMd5CacheGlobal
 }
+
+var CommitMd5CacheGlobal = false

--- a/inputconfig_test.go
+++ b/inputconfig_test.go
@@ -90,7 +90,8 @@ func TestParseConfigFile(t *testing.T) {
 			EbuildName:       "jan-appimage.ebuild",
 			Description:      "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
 			Homepage:         "https://jan.ai/",
-			Workarounds: map[string]string{
+			Features: map[string]string{},
+				Workarounds: map[string]string{
 				"Test Workaround":            "",
 				"Test Workaround with value": "Values",
 			},
@@ -117,6 +118,7 @@ func TestParseConfigFile(t *testing.T) {
 			Category:         "app-misc",
 			EbuildName:       "anotherrepo-appimage.ebuild",
 			GithubOwner:      "anotherorg",
+			Features:      map[string]string{},
 			Workarounds:      map[string]string{},
 			GithubRepo:       "anotherrepo",
 			License:          "unknown",
@@ -138,6 +140,7 @@ func TestParseConfigFile(t *testing.T) {
 			Category:         "app-misc",
 			Description:      "Go implementation of AppImage tools",
 			EbuildName:       "go-appimage-appimage.ebuild",
+			Features:      map[string]string{},
 			Workarounds:      map[string]string{},
 			GithubOwner:      "probonopd",
 			GithubRepo:       "go-appimage",
@@ -181,6 +184,7 @@ func TestParseConfigFile(t *testing.T) {
 			GithubRepo:       "goreleaser",
 			GithubOwner:      "goreleaser",
 			License:          "MIT License",
+			Features:      map[string]string{},
 			Workarounds:      map[string]string{},
 			IUse:             nil,
 			Programs: map[string]*Program{
@@ -252,6 +256,7 @@ func TestConfigString(t *testing.T) {
 				EbuildName:       "jan-appimage.ebuild",
 				Description:      "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
 				Homepage:         "https://jan.ai/",
+				Features: map[string]string{},
 				Workarounds: map[string]string{
 					"Test Workaround":            "",
 					"Test Workaround with value": "Values",
@@ -299,6 +304,7 @@ Binary amd64=>anotherrepo-${VERSION}.AppImage > jan
 				Category:         "app-misc",
 				EbuildName:       "jan-appimage.ebuild",
 				Description:      "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
+				Features: map[string]string{},
 				Workarounds: map[string]string{
 					"Test Workaround":            "",
 					"Test Workaround with value": "Values",

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -319,7 +319,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          [[ if .WorkaroundCommitMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -319,6 +319,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
+          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          git add metadata/md5-cache/ || true
+          [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -319,7 +319,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -319,7 +319,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if .WorkaroundCommitMd5Cache ]]
+          [[ if .FeatureGenerateMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -363,7 +363,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -363,6 +363,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
+          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          git add metadata/md5-cache/ || true
+          [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -363,7 +363,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if .WorkaroundCommitMd5Cache ]]
+          [[ if .FeatureGenerateMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -363,7 +363,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          [[ if .WorkaroundCommitMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -175,7 +175,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if .WorkaroundCommitMd5Cache ]]
+          [[ if .FeatureGenerateMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -175,7 +175,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          [[ if .WorkaroundCommitMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -175,7 +175,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -175,6 +175,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
+          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          git add metadata/md5-cache/ || true
+          [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -225,7 +225,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
-          [[ if .WorkaroundCommitMd5Cache ]]
+          [[ if .FeatureGenerateMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuild for version ${version}"; then

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -225,6 +225,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
+          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          git add metadata/md5-cache/ || true
+          [[ end ]]
           if git commit -m "Add ebuild for version ${version}"; then
             git pull --rebase &&
             git push

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -225,7 +225,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuild for version ${version}"; then
             git pull --rebase &&
             git push

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -225,7 +225,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
-          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          [[ if .WorkaroundCommitMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuild for version ${version}"; then

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -367,7 +367,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          [[ if .WorkaroundCommitMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -367,6 +367,9 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
+          [[ if index .Workarounds "Commit Md5 Cache" ]]
+          git add metadata/md5-cache/ || true
+          [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -367,7 +367,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -367,7 +367,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          [[ if .WorkaroundCommitMd5Cache ]]
+          [[ if .FeatureGenerateMd5Cache ]]
           git add metadata/md5-cache/ || true
           [[ end ]]
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -211,7 +211,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -180,7 +180,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -185,7 +185,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -193,7 +193,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -9,7 +9,7 @@ Description Kubernetes CLI To Manage Your Clusters In Style!
 Homepage https://k9scli.io/
 License Apache-2.0
 Workaround Version Replacement s/v//g
-Workaround Commit Md5 Cache
+Feature Generate Md5 Cache
 Binary amd64=>k9s_Linux_amd64.tar.gz > k9s > k9s
 -- expected.yaml --
 # Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 1.0.0 Github Binary Release test.config 2026-07-12 00:00:00 +0000 UTC

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -9,6 +9,7 @@ Description Kubernetes CLI To Manage Your Clusters In Style!
 Homepage https://k9scli.io/
 License Apache-2.0
 Workaround Version Replacement s/v//g
+Workaround Commit Md5 Cache
 Binary amd64=>k9s_Linux_amd64.tar.gz > k9s > k9s
 -- expected.yaml --
 # Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 1.0.0 Github Binary Release test.config 2026-07-12 00:00:00 +0000 UTC
@@ -168,6 +169,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
+          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -168,7 +168,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -168,7 +168,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -167,7 +167,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -165,7 +165,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -165,7 +165,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -187,7 +187,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuild for version ${version}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -163,7 +163,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuild for version ${version}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -166,7 +166,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuild for version ${version}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -220,7 +220,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -167,7 +167,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -198,7 +198,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -199,7 +199,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -194,7 +194,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -173,7 +173,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
           git add "./${ebuild_dir}"
-          git add metadata/md5-cache/ || true
           if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
             git pull --rebase &&
             git push

--- a/webAppImage.go
+++ b/webAppImage.go
@@ -49,6 +49,7 @@ func GenerateWebAppImageConfigEntry(pageURL, matchExpr, linkExt string) (*InputC
 		Description:     fmt.Sprintf("%s AppImage", humanizeName(programName)),
 		Homepage:        pageURL,
 		GithubRepo:      packageName,
+		Features:        map[string]string{},
 		Workarounds:     map[string]string{},
 		Programs:        map[string]*Program{},
 		License:         DefaultLicense,


### PR DESCRIPTION
This fixes an issue where the generated workflows attempt to add a directory (`metadata/md5-cache/`) that is typically ignored in version control for this tool.

Changes:
* Removed `git add metadata/md5-cache/ || true` from all `templates/*.tmpl` files.
* Programmatically updated `testdata/txtar/**/*.txtar` via `go test -update-txtar ./...`.
* Verified all tests passed.

---
*PR created automatically by Jules for task [293951033521176304](https://jules.google.com/task/293951033521176304) started by @arran4*