### PR TITLE
feat: integrate g2 ebuild deduplicate into workflow templates

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -257,6 +257,7 @@ jobs:
 [[ end ]]
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -301,6 +301,7 @@ jobs:
 [[ end ]]
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -148,6 +148,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -173,6 +173,7 @@ jobs:
 [[ end ]]
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -305,6 +305,7 @@ jobs:
 [[ end ]]
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -193,6 +193,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -162,6 +162,7 @@ jobs:
               touch built.txt
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -167,6 +167,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -175,6 +175,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -151,6 +151,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -150,6 +150,7 @@ jobs:
               touch built.txt
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -149,6 +149,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -147,6 +147,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -147,6 +147,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -168,6 +168,7 @@ jobs:
             g2 manifest upsert-from-url "$appimage_url" "${{ env.epn }}-${version}.${appimage_extension}" "${ebuild_dir}/Manifest"
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -144,6 +144,7 @@ jobs:
             touch built.txt
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -147,6 +147,7 @@ jobs:
             g2 manifest upsert-from-url "$appimage_url" "${{ env.epn }}-${version}.${appimage_extension}" "${ebuild_dir}/Manifest"
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -202,6 +202,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -149,6 +149,7 @@ jobs:
               touch built.txt
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -180,6 +180,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -181,6 +181,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -176,6 +176,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -155,6 +155,7 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+          g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay
         run: |


### PR DESCRIPTION
This PR introduces `g2 ebuild deduplicate "${ebuild_dir}"` into all five generator templates. It takes advantage of the latest `g2` (v0.0.87) to keep overlays clean from older or duplicated ebuild files automatically. Tests have been updated via `-update-txtar`.

---
*PR created automatically by Jules for task [1778192072605948337](https://jules.google.com/task/1778192072605948337) started by @arran4*