### PR TITLE
feat: Add PreVersionSteps for custom Web Binary URLs and extraction tools

### DIFF
--- a/inputconfig.go
+++ b/inputconfig.go
@@ -212,8 +212,8 @@ func (p *Program) ShellCompletion(shell string) (result []*KeywordedFilenameRefe
 
 // InputConfig represents a single configuration entry.
 type InputConfig struct {
-	EntryNumber      int
-	Type             string
+	EntryNumber         int
+	Type                string
 	GithubProjectUrl    string
 	DownloadPageUrl     string
 	DownloadRedirect    string
@@ -223,20 +223,21 @@ type InputConfig struct {
 	CustomDownloadUrl   string
 	CustomVersionSource string
 	CustomBuildSteps    string
+	PreVersionSteps     string
 	Category            string
-	EbuildName       string
-	Description      string
-	Homepage         string
-	GithubRepo       string
-	GithubOwner      string
-	License          string
-	MaintainerEmail  string
-	MaintainerName   string
-	Features         map[string]string
-	Workarounds      map[string]string
-	Programs         map[string]*Program
-	IUse             []string
-	RequiredUse      []string
+	EbuildName          string
+	Description         string
+	Homepage            string
+	GithubRepo          string
+	GithubOwner         string
+	License             string
+	MaintainerEmail     string
+	MaintainerName      string
+	Features            map[string]string
+	Workarounds         map[string]string
+	Programs            map[string]*Program
+	IUse                []string
+	RequiredUse         []string
 }
 
 func (ic *InputConfig) GetPrograms() map[string]*Program {
@@ -269,6 +270,9 @@ func (ic *InputConfig) String() string {
 		if ic.CustomBuildSteps != "" {
 			fmt.Fprintf(&sb, "CustomBuildSteps %s\n", ic.CustomBuildSteps)
 		}
+		if ic.PreVersionSteps != "" {
+			fmt.Fprintf(&sb, "PreVersionSteps %s\n", ic.PreVersionSteps)
+		}
 		if ic.TagsCommand != "" {
 			fmt.Fprintf(&sb, "TagsCommand %s\n", ic.TagsCommand)
 		}
@@ -298,6 +302,9 @@ func (ic *InputConfig) String() string {
 		}
 		if ic.CustomBuildSteps != "" {
 			fmt.Fprintf(&sb, "CustomBuildSteps %s\n", ic.CustomBuildSteps)
+		}
+		if ic.PreVersionSteps != "" {
+			fmt.Fprintf(&sb, "PreVersionSteps %s\n", ic.PreVersionSteps)
 		}
 		if ic.TagsCommand != "" {
 			fmt.Fprintf(&sb, "TagsCommand %s\n", ic.TagsCommand)
@@ -363,6 +370,9 @@ func (ic *InputConfig) String() string {
 		}
 		if ic.CustomBuildSteps != "" {
 			fmt.Fprintf(&sb, "CustomBuildSteps %s\n", ic.CustomBuildSteps)
+		}
+		if ic.PreVersionSteps != "" {
+			fmt.Fprintf(&sb, "PreVersionSteps %s\n", ic.PreVersionSteps)
 		}
 		if ic.TagsCommand != "" {
 			fmt.Fprintf(&sb, "TagsCommand %s\n", ic.TagsCommand)
@@ -487,6 +497,7 @@ func ParseInputConfigReader(file io.Reader) ([]*InputConfig, error) {
 				"CustomDownloadUrl":     nil,
 				"CustomVersionSource":   nil,
 				"CustomBuildSteps":      nil,
+				"PreVersionSteps":       nil,
 				"TagsCommand":           nil,
 				"Category":              {DefaultCategory},
 				"EbuildName":            nil,
@@ -677,9 +688,18 @@ func CreateSanitizeAndAppendInputConfig(parsedFields map[string][]string, parsed
 	if err != nil {
 		return nil, fmt.Errorf("on CustomBuildSteps: %v: %w", parsedFields["CustomBuildSteps"], err)
 	}
+	currentConfig.PreVersionSteps, err = emptyOrOnlyOrFail(parsedFields["PreVersionSteps"])
+	if err != nil {
+		return nil, fmt.Errorf("on PreVersionSteps: %v: %w", parsedFields["PreVersionSteps"], err)
+	}
 	currentConfig.MaintainerName, err = emptyOrOnlyOrFail(parsedFields["MaintainerName"])
 	if err != nil {
 		return nil, fmt.Errorf("on MaintainerName: %v: %w", parsedFields["MaintainerName"], err)
+	}
+	if currentConfig.Type == "Web Binary" {
+		if currentConfig.TagsCommand == "" && currentConfig.CustomVersionSource == "" {
+			return nil, fmt.Errorf("TagsCommand or CustomVersionSource is required for Web Binary configurations")
+		}
 	}
 	if currentConfig.Type == "Github AppImage Release" || currentConfig.Type == "Github Binary Release" || currentConfig.Type == "Github Cmake Release" {
 		currentConfig.GithubOwner, currentConfig.GithubRepo, err = util.ExtractGithubOwnerRepo(currentConfig.GithubProjectUrl)
@@ -1063,7 +1083,7 @@ func NewInputConfigurationFromRepo(gitRepo, tagOverride, tagPrefix, ebuildSuffix
 		Homepage:    util.StringOrDefault(repo.Homepage, ""),
 		GithubRepo:  repoName,
 		GithubOwner: ownerName,
-		Features: map[string]string{},
+		Features:    map[string]string{},
 		Workarounds: map[string]string{},
 		Programs:    map[string]*Program{},
 		License:     util.StringOrDefault(licenseName, "unknown"),

--- a/inputconfig_test.go
+++ b/inputconfig_test.go
@@ -15,6 +15,7 @@ TagsCommand cat tags.txt
 CustomDownloadUrl https://custom.url/${version}
 CustomVersionSource echo "v1.2.3"
 CustomBuildSteps touch built.txt
+PreVersionSteps echo "PreVersionSteps"
 DesktopFile jan
 Category app-misc
 EbuildName jan-appimage
@@ -79,19 +80,20 @@ func TestParseConfigFile(t *testing.T) {
 
 	expectedConfigs := []*InputConfig{
 		{
-			EntryNumber:      0,
-			Type:             "Github AppImage Release",
-			GithubProjectUrl: "https://github.com/janhq/jan/",
-			TagsCommand:      "cat tags.txt",
-			CustomDownloadUrl: "https://custom.url/${version}",
+			EntryNumber:         0,
+			Type:                "Github AppImage Release",
+			GithubProjectUrl:    "https://github.com/janhq/jan/",
+			TagsCommand:         "cat tags.txt",
+			CustomDownloadUrl:   "https://custom.url/${version}",
 			CustomVersionSource: "echo \"v1.2.3\"",
-			CustomBuildSteps: "touch built.txt",
-			Category:         "app-misc",
-			EbuildName:       "jan-appimage.ebuild",
-			Description:      "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
-			Homepage:         "https://jan.ai/",
-			Features: map[string]string{},
-				Workarounds: map[string]string{
+			CustomBuildSteps:    "touch built.txt",
+			PreVersionSteps:     "echo \"PreVersionSteps\"",
+			Category:            "app-misc",
+			EbuildName:          "jan-appimage.ebuild",
+			Description:         "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
+			Homepage:            "https://jan.ai/",
+			Features:            map[string]string{},
+			Workarounds: map[string]string{
 				"Test Workaround":            "",
 				"Test Workaround with value": "Values",
 			},
@@ -118,7 +120,7 @@ func TestParseConfigFile(t *testing.T) {
 			Category:         "app-misc",
 			EbuildName:       "anotherrepo-appimage.ebuild",
 			GithubOwner:      "anotherorg",
-			Features:      map[string]string{},
+			Features:         map[string]string{},
 			Workarounds:      map[string]string{},
 			GithubRepo:       "anotherrepo",
 			License:          "unknown",
@@ -140,7 +142,7 @@ func TestParseConfigFile(t *testing.T) {
 			Category:         "app-misc",
 			Description:      "Go implementation of AppImage tools",
 			EbuildName:       "go-appimage-appimage.ebuild",
-			Features:      map[string]string{},
+			Features:         map[string]string{},
 			Workarounds:      map[string]string{},
 			GithubOwner:      "probonopd",
 			GithubRepo:       "go-appimage",
@@ -184,7 +186,7 @@ func TestParseConfigFile(t *testing.T) {
 			GithubRepo:       "goreleaser",
 			GithubOwner:      "goreleaser",
 			License:          "MIT License",
-			Features:      map[string]string{},
+			Features:         map[string]string{},
 			Workarounds:      map[string]string{},
 			IUse:             nil,
 			Programs: map[string]*Program{
@@ -245,18 +247,19 @@ func TestConfigString(t *testing.T) {
 		{
 			name: "jan-appimage",
 			config: &InputConfig{
-				EntryNumber:      0,
-				Type:             "Github AppImage Release",
-				GithubProjectUrl: "https://github.com/janhq/jan/",
-				TagsCommand:      "cat tags.txt",
-				CustomDownloadUrl: "https://custom.url/${version}",
+				EntryNumber:         0,
+				Type:                "Github AppImage Release",
+				GithubProjectUrl:    "https://github.com/janhq/jan/",
+				TagsCommand:         "cat tags.txt",
+				CustomDownloadUrl:   "https://custom.url/${version}",
 				CustomVersionSource: "echo \"v1.2.3\"",
-				CustomBuildSteps: "touch built.txt",
-				Category:         "app-misc",
-				EbuildName:       "jan-appimage.ebuild",
-				Description:      "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
-				Homepage:         "https://jan.ai/",
-				Features: map[string]string{},
+				CustomBuildSteps:    "touch built.txt",
+				PreVersionSteps:     "echo \"PreVersionSteps\"",
+				Category:            "app-misc",
+				EbuildName:          "jan-appimage.ebuild",
+				Description:         "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
+				Homepage:            "https://jan.ai/",
+				Features:            map[string]string{},
 				Workarounds: map[string]string{
 					"Test Workaround":            "",
 					"Test Workaround with value": "Values",
@@ -278,6 +281,7 @@ GithubProjectUrl https://github.com/janhq/jan/
 CustomDownloadUrl https://custom.url/${version}
 CustomVersionSource echo "v1.2.3"
 CustomBuildSteps touch built.txt
+PreVersionSteps echo "PreVersionSteps"
 TagsCommand cat tags.txt
 Category app-misc
 EbuildName jan-appimage.ebuild
@@ -294,17 +298,18 @@ Binary amd64=>anotherrepo-${VERSION}.AppImage > jan
 		{
 			name: "jan-appimage-custom",
 			config: &InputConfig{
-				EntryNumber:      1,
-				Type:             "Github AppImage Release",
-				GithubProjectUrl: "https://github.com/janhq/jan/",
-				TagsCommand:      "cat tags.txt",
-				CustomDownloadUrl: "https://custom.url/${version}",
+				EntryNumber:         1,
+				Type:                "Github AppImage Release",
+				GithubProjectUrl:    "https://github.com/janhq/jan/",
+				TagsCommand:         "cat tags.txt",
+				CustomDownloadUrl:   "https://custom.url/${version}",
 				CustomVersionSource: "echo \"v1.2.3\"",
-				CustomBuildSteps: "touch built.txt",
-				Category:         "app-misc",
-				EbuildName:       "jan-appimage.ebuild",
-				Description:      "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
-				Features: map[string]string{},
+				CustomBuildSteps:    "touch built.txt",
+				PreVersionSteps:     "echo \"PreVersionSteps\"",
+				Category:            "app-misc",
+				EbuildName:          "jan-appimage.ebuild",
+				Description:         "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer. Multiple engine support (llama.cpp, TensorRT-LLM)",
+				Features:            map[string]string{},
 				Workarounds: map[string]string{
 					"Test Workaround":            "",
 					"Test Workaround with value": "Values",
@@ -329,6 +334,7 @@ GithubProjectUrl https://github.com/janhq/jan/
 CustomDownloadUrl https://custom.url/${version}
 CustomVersionSource echo "v1.2.3"
 CustomBuildSteps touch built.txt
+PreVersionSteps echo "PreVersionSteps"
 TagsCommand cat tags.txt
 Category app-misc
 EbuildName jan-appimage.ebuild

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -62,6 +62,9 @@ jobs:
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           declare -A releaseTypes=()
+          [[ if .PreVersionSteps ]]
+          [[ .PreVersionSteps ]]
+          [[ end ]]
           [[ if .CustomVersionSource ]]
           tags=$([[ .CustomVersionSource ]])
           [[ else if .TagsCommand ]]

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -62,6 +62,9 @@ jobs:
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           declare -A releaseTypes=()
+          [[ if .PreVersionSteps ]]
+          [[ .PreVersionSteps ]]
+          [[ end ]]
           [[ if .CustomVersionSource ]]
           tags=$([[ .CustomVersionSource ]])
           [[ else if .TagsCommand ]]

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -54,6 +54,9 @@ jobs:
         id: find_appimage
         run: |
           set -euo pipefail
+          [[- if .PreVersionSteps ]]
+          [[ .PreVersionSteps ]]
+          [[- end ]]
           [[- if .CustomVersionSource ]]
           version=$([[ .CustomVersionSource ]])
           [[- end ]]

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -62,6 +62,9 @@ jobs:
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
           declare -A releaseTypes=()
+          [[ if .PreVersionSteps ]]
+          [[ .PreVersionSteps ]]
+          [[ end ]]
           [[ if .CustomVersionSource ]]
           tags=$([[ .CustomVersionSource ]])
           [[ else ]]

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -1,0 +1,189 @@
+This fixture tests Web Binary rendering with all custom injection points.
+
+-- input.config --
+Type Web Binary
+EbuildName example-bin
+Category app-misc
+Description Example Bin
+Homepage https://example.com/
+License MIT
+DownloadBaseUrl https://example.com/downloads/
+PreVersionSteps echo "Fetching RSS feed to extract latest tag" > /tmp/log
+TagsCommand curl -sL https://example.com/feed.xml | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*'
+CustomDownloadUrl https://example.com/archive/${version}/example.tar.gz
+CustomBuildSteps echo "Built successfully"
+ProgramName example
+Binary amd64=>example-linux-amd64.tar.gz > example > example
+
+-- expected.yaml --
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 1.0.0 Web Binary test.config 2026-07-12 00:00:00 +0000 UTC
+
+name: app-misc/example-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '24 2 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-misc-example-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: app-misc
+  epn: example-bin
+  description: "Example Bin"
+  homepage: "https://example.com/"
+  github_owner:
+  github_repo: example-bin
+  keywords: ~amd64
+  workflow_filename: app-misc-example-bin-update.yaml
+  example_binary_installed_name: 'example'
+  example_binary_archived_name_amd64: 'example'
+  example_release_name_amd64: 'example-linux-amd64.tar.gz'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" "$metadata_file"
+          declare -A releaseTypes=()
+          echo "Fetching RSS feed to extract latest tag" > /tmp/log
+          if [ -z "curl -sL https://example.com/feed.xml | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*'" ]; then
+             echo "TagsCommand is required for Web Binary configurations" >&2
+             exit 1
+          fi
+          tags=$(curl -sL https://example.com/feed.xml | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#v}"
+            if echo "$tag" | grep -qE '^v?[0-9]'; then
+                version="${tag#v}"
+            elif [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'SRC_URI="'
+                echo "	amd64? (  https://example.com/archive/${version}/example.tar.gz -> \${P}-example-linux-amd64.tar.gz  )  "
+                echo '"'
+                echo 'LICENSE="MIT"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo -n 'IUSE="'
+                echo -n ' amd64'
+                echo '"'
+                echo ''
+                echo -n 'REQUIRED_USE="'
+                echo '"'
+                echo ''
+                echo -n 'RDEPEND="'
+                echo '"'
+                echo ''
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-example-linux-amd64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.example_binary_archived_name_amd64 }}" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '}'
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              # Manifest generation
+              failed=0
+              if ! g2 manifest upsert-from-url "https://example.com/archive/${version}/example.tar.gz" "${{ env.epn }}-${version}-example-linux-amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "Built successfully"
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+          g2 ebuild deduplicate "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles
+          echo "overlay_name" > profiles/repo_name
+          echo "8" > profiles/eapi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag


### PR DESCRIPTION
This PR adds `PreVersionSteps` to the `InputConfig` to allow auxiliary commands to execute prior to retrieving tags (e.g. downloading `htmlq` or `jq` via curl to parse version files), addressing edge cases for custom Web Binary releases.

It also tightens the constraints on `Web Binary` setups, properly verifying that either `TagsCommand` or `CustomVersionSource` is present before executing templates, fulfilling the criteria for "Support for Custom Download URLs and Artifact Extraction" in issue #67. Full txtar testing coverage has been implemented for this feature.

---
*PR created automatically by Jules for task [4469935971314136410](https://jules.google.com/task/4469935971314136410) started by @arran4*