### PR TITLE
Fix #97: Resolves empty variables in generated bash scripts by removing intermediate Github Actions environment variables

### DIFF
--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -241,6 +241,8 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 			},
 			"quoteStr": strconv.Quote,
 			"actionvardoublequoted": func(s string) string {
+				s = strings.ReplaceAll(s, "{{.Tag}}", "${tag}")
+				s = strings.ReplaceAll(s, "{{.Version}}", "${version}")
 				return os.Expand(s, func(s string) string {
 					switch s {
 					case "VERSION":
@@ -258,6 +260,8 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 			},
 			"UseFlagSafe": strcase.SnakeCase,
 			"ebuildvardoublequoted": func(s string) string {
+				s = strings.ReplaceAll(s, "{{.Tag}}", "${tag}")
+				s = strings.ReplaceAll(s, "{{.Version}}", "\\${PV}")
 				return os.Expand(s, func(s string) string {
 					switch s {
 					case "VERSION":
@@ -282,6 +286,8 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 			"shell_echo": ShellEchoEvalContent,
 			"shell_echo_literal": ShellEchoContent,
 			"ebuildvardoublequotedSemanticVersionPrereleaseHack1": func(s string) string {
+				s = strings.ReplaceAll(s, "{{.Tag}}", "${tag}")
+				s = strings.ReplaceAll(s, "{{.Version}}", "${originalVersion}")
 				return os.Expand(s, func(s string) string {
 					switch s {
 					case "VERSION":

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -35,7 +35,6 @@ env:
   [[- if gt (len $binary) 2 ]]
   [[ join (filterEmpty $pname "appimage_archived_name" $keyword) "_" ]]: '[[ index $binary 1 ]]'
   [[ end ]]
-  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | actionvardoublequoted ]]'
   [[ end ]]
   [[ end ]]
 
@@ -151,7 +150,7 @@ jobs:
                 echo '  fi'
   [[ else ]]
                 echo '  if use [[ $keyword ]]; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.[[ join (filterEmpty $pname "release_name" $keyword) "_" ]] }}\" \"${{ env.[[ join (filterEmpty $pname "appimage_installed_name" ) "_" ]] }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-[[ index $binary 0 | ebuildvardoublequoted ]]\" \"${{ env.[[ join (filterEmpty $pname "appimage_installed_name" ) "_" ]] }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
   [[ end ]]
 [[ end ]]

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -35,7 +35,6 @@ env:
   [[- if gt (len $binary) 2 ]]
   [[ join (filterEmpty $pname "binary_archived_name" $keyword) "_" ]]: '[[ index $binary 1 ]]'
   [[ end ]]
-  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | actionvardoublequoted ]]'
   [[ end ]]
   [[ end ]]
 
@@ -222,7 +221,7 @@ jobs:
     [[ else ]]
         [[- $count := 0 ]]
                 echo '  if [[range $i, $uf := $.GetMustHaveUseFlags $pname $keyword ]][[ if gt $count 0]] && [[ end ]][[ $count = 1]]use [[ $uf ]][[end]][[range $i, $uf := $.GetMustntHaveUseFlags $pname $keyword ]][[ if gt $count 0]] && [[ end ]][[ $count = 1]]! use [[ $uf ]] [[end]]; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.[[ join (filterEmpty $pname "release_name" $keyword) "_" ]] }}" "${{ env.[[ join (filterEmpty $pname "binary_installed_name" ) "_" ]] }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"[[ index $binary 0 | ebuildvardoublequoted ]]"'" "${{ env.[[ join (filterEmpty $pname "binary_installed_name" ) "_" ]] }}" || die "Failed to install Binary"'
                 echo '  fi'
     [[ end ]]
   [[ end ]]

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -35,7 +35,6 @@ env:
   [[- if gt (len $binary) 2 ]]
   [[ join (filterEmpty $pname "binary_archived_name" $keyword) "_" ]]: '[[ index $binary 1 ]]'
   [[ end ]]
-  [[ join (filterEmpty $pname "release_name" $keyword) "_" ]]: '[[ index $binary 0 | actionvardoublequoted ]]'
   [[ end ]]
   [[ end ]]
 
@@ -226,7 +225,7 @@ jobs:
     [[ else ]]
         [[- $count := 0 ]]
                 echo '  if [[range $i, $uf := $.GetMustHaveUseFlags $pname $keyword ]][[ if gt $count 0]] && [[ end ]][[ $count = 1]]use [[ $uf ]][[end]][[range $i, $uf := $.GetMustntHaveUseFlags $pname $keyword ]][[ if gt $count 0]] && [[ end ]][[ $count = 1]]! use [[ $uf ]] [[end]]; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.[[ join (filterEmpty $pname "release_name" $keyword) "_" ]] }}" "${{ env.[[ join (filterEmpty $pname "binary_installed_name" ) "_" ]] }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"[[ index $binary 0 | ebuildvardoublequoted ]]"'" "${{ env.[[ join (filterEmpty $pname "binary_installed_name" ) "_" ]] }}" || die "Failed to install Binary"'
                 echo '  fi'
     [[ end ]]
   [[ end ]]

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -50,8 +50,6 @@ env:
   workflow_filename: net-misc-rustdesk-appimage-update.yaml
   rustdesk_desktop_file: 'rustdesk.desktop'
   rustdesk_appimage_installed_name: 'rustdesk.AppImage'
-  rustdesk_release_name_amd64: 'rustdesk-${tag}-x86_64.AppImage'
-  rustdesk_release_name_arm64: 'rustdesk-${tag}-aarch64.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -123,10 +121,10 @@ jobs:
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.rustdesk_release_name_amd64 }}\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-rustdesk-${tag}-x86_64.AppImage\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.rustdesk_release_name_arm64 }}\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-rustdesk-${tag}-aarch64.AppImage\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  chmod a+x "${{ env.rustdesk_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.rustdesk_appimage_installed_name }}" --appimage-extract "${{ env.rustdesk_desktop_file }}" || die "Failed to extract .desktop from appimage"'

--- a/testdata/txtar/github-appimage/custom_download_url.txtar
+++ b/testdata/txtar/github-appimage/custom_download_url.txtar
@@ -42,7 +42,6 @@ env:
   keywords: ~amd64
   workflow_filename: net-misc-example-appimage-update.yaml
   example_appimage_installed_name: 'example-${TAG}.AppImage'
-  example_release_name_amd64: 'example-${tag}.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -111,7 +110,7 @@ jobs:
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.example_release_name_amd64 }}\" \"${{ env.example_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-example-${tag}.AppImage\" \"${{ env.example_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  chmod a+x "${{ env.example_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '}'

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -46,7 +46,6 @@ env:
   workflow_filename: app-misc-example-appimage-update.yaml
   example_desktop_file: 'example.desktop'
   example_appimage_installed_name: 'example'
-  example_release_name_amd64: 'example-linux-x86_64-${version}.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -117,7 +116,7 @@ jobs:
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.example_release_name_amd64 }}\" \"${{ env.example_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-example-linux-x86_64-\${PV}.AppImage\" \"${{ env.example_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  chmod a+x "${{ env.example_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.example_appimage_installed_name }}" --appimage-extract "${{ env.example_desktop_file }}" || die "Failed to extract .desktop from appimage"'

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -47,7 +47,6 @@ env:
   workflow_filename: net-misc-localsend-appimage-update.yaml
   localsend_desktop_file: 'localsend_app.desktop'
   localsend_appimage_installed_name: 'localsend_app'
-  localsend_release_name_amd64: 'LocalSend-${tag}-linux-x86-64.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -118,7 +117,7 @@ jobs:
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.localsend_release_name_amd64 }}\" \"${{ env.localsend_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-LocalSend-${tag}-linux-x86-64.AppImage\" \"${{ env.localsend_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  chmod a+x "${{ env.localsend_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.localsend_appimage_installed_name }}" --appimage-extract "${{ env.localsend_desktop_file }}" || die "Failed to extract .desktop from appimage"'

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -49,8 +49,6 @@ env:
   workflow_filename: net-misc-rustdesk-appimage-update.yaml
   rustdesk_desktop_file: 'rustdesk.desktop'
   rustdesk_appimage_installed_name: 'rustdesk.AppImage'
-  rustdesk_release_name_amd64: 'rustdesk-${tag}-x86_64.AppImage'
-  rustdesk_release_name_arm64: 'rustdesk-${tag}-aarch64.AppImage'
 
 jobs:
   check-and-create-ebuild:
@@ -122,10 +120,10 @@ jobs:
                 echo ''
                 echo 'src_unpack() {'
                 echo '  if use amd64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.rustdesk_release_name_amd64 }}\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-rustdesk-${tag}-x86_64.AppImage\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  if use arm64; then'
-                echo "    cp \"\${DISTDIR}/\${P}-${{ env.rustdesk_release_name_arm64 }}\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo "    cp \"\${DISTDIR}/\${P}-rustdesk-${tag}-aarch64.AppImage\" \"${{ env.rustdesk_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
                 echo '  fi'
                 echo '  chmod a+x "${{ env.rustdesk_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
                 echo '  "./${{ env.rustdesk_appimage_installed_name }}" --appimage-extract "${{ env.rustdesk_desktop_file }}" || die "Failed to extract .desktop from appimage"'

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -42,7 +42,6 @@ env:
   workflow_filename: app-admin-k9s-bin-update.yaml
   binary_installed_name: 'k9s'
   binary_archived_name_amd64: 'k9s'
-  release_name_amd64: 'k9s_Linux_amd64.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -42,7 +42,6 @@ env:
   keywords: ~amd64
   workflow_filename: net-misc-example-bin-update.yaml
   example_binary_installed_name: 'example-${TAG}.tar.gz'
-  example_release_name_amd64: 'example-${tag}.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -123,7 +122,7 @@ jobs:
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.example_release_name_amd64 }}" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"example-${tag}.tar.gz"'" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -44,7 +44,6 @@ env:
   keywords: ~amd64
   workflow_filename: app-misc-example-bin-update.yaml
   example_binary_installed_name: 'example'
-  example_release_name_amd64: 'example-linux-x86_64-${version}.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -125,7 +124,7 @@ jobs:
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.example_release_name_amd64 }}" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"example-linux-x86_64-\${PV}.tar.gz"'" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -44,7 +44,6 @@ env:
   keywords: ~amd64
   workflow_filename: app-misc-tool-bin-update.yaml
   tool_binary_installed_name: 'tool'
-  tool_release_name_amd64: 'tool-${tag}-amd64'
 
 jobs:
   check-and-create-ebuild:
@@ -125,7 +124,7 @@ jobs:
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.tool_release_name_amd64 }}" "${{ env.tool_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"tool-${tag}-amd64"'" "${{ env.tool_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -47,11 +47,8 @@ env:
   workflow_filename: app-admin-google-cloud-sdk-bin-update.yaml
   google-cloud-cli_binary_installed_name: 'gcloud'
   google-cloud-cli_binary_archived_name_amd64: 'gcloud'
-  google-cloud-cli_release_name_amd64: 'google-cloud-cli-${version}-linux-x86_64.tar.gz'
   google-cloud-cli_binary_archived_name_arm64: 'gcloud'
-  google-cloud-cli_release_name_arm64: 'google-cloud-cli-${version}-linux-arm.tar.gz'
   google-cloud-cli_binary_archived_name_x86: 'gcloud'
-  google-cloud-cli_release_name_x86: 'google-cloud-cli-${version}-linux-x86.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -42,7 +42,6 @@ env:
   keywords: ~amd64
   workflow_filename: net-misc-example-bin-update.yaml
   example_binary_installed_name: 'example-${TAG}.tar.gz'
-  example_release_name_amd64: 'example-${tag}.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -129,7 +128,7 @@ jobs:
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.example_release_name_amd64 }}" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"example-${tag}.tar.gz"'" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -46,7 +46,6 @@ env:
   workflow_filename: app-misc-example-bin-update.yaml
   example_binary_installed_name: 'example'
   example_binary_archived_name_amd64: 'example'
-  example_release_name_amd64: 'example-linux-amd64.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -41,7 +41,6 @@ env:
   keywords: ~amd64
   workflow_filename: app-misc-example-bin-update.yaml
   example_binary_installed_name: 'example'
-  example_release_name_amd64: 'example-${version}.tar.gz'
 
 jobs:
   check-and-create-ebuild:
@@ -124,7 +123,7 @@ jobs:
                 echo 'src_install() {'
                 echo '  exeinto /opt/bin'
                 echo '  if use amd64; then'
-                echo '    newexe "${DISTDIR}/${P}-${{ env.example_release_name_amd64 }}" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '    newexe "${DISTDIR}/${P}-'"example-\${PV}.tar.gz"'" "${{ env.example_binary_installed_name }}" || die "Failed to install Binary"'
                 echo '  fi'
                 echo '}'
               } > "$tmp_ebuild_file"

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -45,11 +45,8 @@ env:
   workflow_filename: app-admin-google-cloud-sdk-bin-update.yaml
   google-cloud-cli_binary_installed_name: 'gcloud'
   google-cloud-cli_binary_archived_name_amd64: 'gcloud'
-  google-cloud-cli_release_name_amd64: 'google-cloud-cli-${version}-linux-x86_64.tar.gz'
   google-cloud-cli_binary_archived_name_arm64: 'gcloud'
-  google-cloud-cli_release_name_arm64: 'google-cloud-cli-${version}-linux-arm.tar.gz'
   google-cloud-cli_binary_archived_name_x86: 'gcloud'
-  google-cloud-cli_release_name_x86: 'google-cloud-cli-${version}-linux-x86.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -46,11 +46,8 @@ env:
   workflow_filename: app-admin-google-cloud-sdk-bin-update.yaml
   google-cloud-cli_binary_installed_name: 'gcloud'
   google-cloud-cli_binary_archived_name_amd64: 'gcloud'
-  google-cloud-cli_release_name_amd64: 'google-cloud-cli-${version}-linux-x86_64.tar.gz'
   google-cloud-cli_binary_archived_name_arm64: 'gcloud'
-  google-cloud-cli_release_name_arm64: 'google-cloud-cli-${version}-linux-arm.tar.gz'
   google-cloud-cli_binary_archived_name_x86: 'gcloud'
-  google-cloud-cli_release_name_x86: 'google-cloud-cli-${version}-linux-x86.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -50,7 +50,6 @@ env:
   workflow_filename: net-misc-rustdesk-bin-update.yaml
   rustdesk_binary_installed_name: 'rustdesk'
   rustdesk_binary_archived_name_amd64: 'rustdesk'
-  rustdesk_release_name_amd64: 'rustdesk-${version}-x86_64.tar.gz'
 
 jobs:
   check-and-create-ebuild:

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -49,7 +49,6 @@ env:
   workflow_filename: net-misc-rustdesk-bin-update.yaml
   rustdesk_binary_installed_name: 'rustdesk'
   rustdesk_binary_archived_name_amd64: 'rustdesk'
-  rustdesk_release_name_amd64: 'rustdesk-${version}-x86_64.tar.gz'
 
 jobs:
   check-and-create-ebuild:


### PR DESCRIPTION
Fixes #97 by avoiding the use of `$GITHUB_ENV` to pass `release_name` strings into the generated workflow scripts, which caused literal strings like `${version}` to be evaluated dynamically by `portage`/`bash` (and fail as empty strings). Instead, directly resolves the Go template properties into the workflow script via `ebuildvardoublequoted`. Additionally, supports mapping explicit `{{.Version}}` and `{{.Tag}}` user configurations natively inside `generateWorkflows.go`.

---
*PR created automatically by Jules for task [14203656590010343317](https://jules.google.com/task/14203656590010343317) started by @arran4*