### PR TITLE
fix(workflows): Extract g2 ebuild deduplicate into a standalone step

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -255,6 +255,10 @@ jobs:
 [[ end ]]
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -303,6 +303,10 @@ jobs:
 [[ end ]]
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -148,6 +148,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -186,6 +186,10 @@ jobs:
 [[ end ]]
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -307,6 +307,10 @@ jobs:
 [[ end ]]
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -192,6 +192,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-appimage/custom_download_url.txtar
+++ b/testdata/txtar/github-appimage/custom_download_url.txtar
@@ -145,6 +145,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -161,6 +161,10 @@ jobs:
               touch built.txt
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -166,6 +166,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -174,6 +174,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -150,6 +150,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -146,6 +146,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -149,6 +149,10 @@ jobs:
               touch built.txt
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -148,6 +148,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -147,6 +147,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -147,6 +147,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -166,6 +166,10 @@ jobs:
             g2 manifest upsert-from-url "$appimage_url" "${{ env.epn }}-${version}.${appimage_extension}" "${ebuild_dir}/Manifest"
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -142,6 +142,10 @@ jobs:
             touch built.txt
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -145,6 +145,10 @@ jobs:
             g2 manifest upsert-from-url "$appimage_url" "${{ env.epn }}-${version}.${appimage_extension}" "${ebuild_dir}/Manifest"
             echo "generated_tag=${version}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -201,6 +201,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -152,6 +152,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -162,6 +162,10 @@ jobs:
               echo "Built successfully"
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -148,6 +148,10 @@ jobs:
               touch built.txt
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -179,6 +179,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -180,6 +180,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -175,6 +175,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -154,6 +154,10 @@ jobs:
               fi
               echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
           done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
       - name: Generate Overlay


### PR DESCRIPTION
Resolves #99 by adding `g2 ebuild deduplicate` as a standalone GitHub Actions step right after the releases are processed.

---
*PR created automatically by Jules for task [5077314759518909741](https://jules.google.com/task/5077314759518909741) started by @arran4*