### PR TITLE
Fixes #68: Update actions/checkout version to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       release_tag: ${{ steps.tag.outputs.release_tag }}
       next_version: ${{ steps.tag.outputs.next_version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup git-tag-inc
@@ -223,7 +223,7 @@ jobs:
         }}
       has_packaging: ${{ steps.detect.outputs.has_packaging }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - id: detect
         shell: bash
         run: "set -euo pipefail\n# Keep this minimal: most language choices should\
@@ -256,7 +256,7 @@ jobs:
       == 'true' || needs.route.outputs.is_monthly == 'true') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v3
@@ -271,7 +271,7 @@ jobs:
       == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
@@ -294,7 +294,7 @@ jobs:
         os:
           - ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
@@ -310,7 +310,7 @@ jobs:
       == 'true' && needs.discover.outputs.profile == 'public' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
@@ -325,7 +325,7 @@ jobs:
       && inputs.mode == 'lint-fix' && inputs.allow_prs == true }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
@@ -350,7 +350,7 @@ jobs:
       && inputs.allow_prs == true }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - name: Setup Go (if needed)
         if: ${{ needs.discover.outputs.has_go == 'true' }}
         uses: actions/setup-go@v7
@@ -397,7 +397,7 @@ jobs:
     if: ${{ needs.route.outputs.run_cleanup == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PARENT_PR: ${{ github.event.pull_request.number }}
@@ -421,7 +421,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v7

--- a/orig/app-accessibility-whisperfiles-bin-update.yaml
+++ b/orig/app-accessibility-whisperfiles-bin-update.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/app-admin-chezmoi-bin-update.yaml
+++ b/orig/app-admin-chezmoi-bin-update.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/app-admin-g2-bin-update.yaml
+++ b/orig/app-admin-g2-bin-update.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/app-misc-appimagetool-appimage-update.yaml
+++ b/orig/app-misc-appimagetool-appimage-update.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/app-misc-go-appimage-appimage-update.yaml
+++ b/orig/app-misc-go-appimage-appimage-update.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/app-text-jbofihe-update.yaml
+++ b/orig/app-text-jbofihe-update.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/dev-go-goreleaser-bin-update.yaml
+++ b/orig/dev-go-goreleaser-bin-update.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/dev-ml-llamafile-bin-update.yaml
+++ b/orig/dev-ml-llamafile-bin-update.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/dev-ml-moondream2-llamafile-bin-update.yaml
+++ b/orig/dev-ml-moondream2-llamafile-bin-update.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/dev-ml-mozilla-llm-compiler-llamafile-bin-update.yaml
+++ b/orig/dev-ml-mozilla-llm-compiler-llamafile-bin-update.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/dev-ml-ollama-bin-update.yaml
+++ b/orig/dev-ml-ollama-bin-update.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/dev-ml-whisperfile-bin-update.yaml
+++ b/orig/dev-ml-whisperfile-bin-update.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/net-im-slackdump-bin-update.yaml
+++ b/orig/net-im-slackdump-bin-update.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/orig/www-apps-hugo-bin-update.yaml
+++ b/orig/www-apps-hugo-bin-update.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-appimage/custom_download_url.txtar
+++ b/testdata/txtar/github-appimage/custom_download_url.txtar
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up Git
         run: |


### PR DESCRIPTION
This fixes Node.js 20 deprecation warnings on GitHub Actions by updating all occurrences of `actions/checkout@v2` (and incorrect `v7` occurrences) to `actions/checkout@v4` across workflow files, templates, generated outputs, and test data.

---
*PR created automatically by Jules for task [819969265271837554](https://jules.google.com/task/819969265271837554) started by @arran4*