### PR TITLE
Fixes #97: allow config variables in src_uri and export them to bash loop

### DIFF
--- a/commit_message
+++ b/commit_message
@@ -1,0 +1,7 @@
+Fixes #97: allow config variables in src_uri and export them to bash loop
+
+Allows templated variables `{{.Tag}}` and `{{.Version}}` to be passed via the `Binary` configuration in `current.config` and expanded cleanly inside generated bash strings, resolving buggy regex substitutions.
+
+Exports `TAG`, `VERSION`, and `originalVersion` explicitly to the environment loop before ebuild generation to ensure variables are available correctly in context for custom URL workarounds like `CustomDownloadUrl`.
+
+Updates tests via `go test -update-txtar ./...`.

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -241,6 +241,8 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 			},
 			"quoteStr": strconv.Quote,
 			"actionvardoublequoted": func(s string) string {
+				s = strings.ReplaceAll(s, "{{.Tag}}", "${tag}")
+				s = strings.ReplaceAll(s, "{{.Version}}", "${version}")
 				return os.Expand(s, func(s string) string {
 					switch s {
 					case "VERSION":
@@ -258,6 +260,8 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 			},
 			"UseFlagSafe": strcase.SnakeCase,
 			"ebuildvardoublequoted": func(s string) string {
+				s = strings.ReplaceAll(s, "{{.Tag}}", "${tag}")
+				s = strings.ReplaceAll(s, "{{.Version}}", "\\${PV}")
 				return os.Expand(s, func(s string) string {
 					switch s {
 					case "VERSION":
@@ -284,6 +288,8 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 			"shell_echo":         ShellEchoEvalContent,
 			"shell_echo_literal": ShellEchoContent,
 			"ebuildvardoublequotedSemanticVersionPrereleaseHack1": func(s string) string {
+				s = strings.ReplaceAll(s, "{{.Tag}}", "${tag}")
+				s = strings.ReplaceAll(s, "{{.Version}}", "${originalVersion}")
 				return os.Expand(s, func(s string) string {
 					switch s {
 					case "VERSION":

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,0 @@
-1. Add explicit string replacement variables `{{.Tag}}` and `{{.Version}}` parsing to `actionvardoublequoted` and `ebuildvardoublequoted` functions in `generateWorkflows.go`.
-2. Ensure bash script inside `github-binary.tmpl`, `github-appimage.tmpl`, `github-cmake.tmpl`, `web-binary.tmpl`, and `web-appimage.tmpl` export the missing `${version}`, `${tag}` (as `TAG`) and `${originalVersion}` variables properly before constructing the `SRC_URI` block, so that it can be used inside `CustomDownloadUrl` or templates correctly (for `replace` calls).
-3. Validate fixes by testing template output with `go test -update-txtar ./...`.
-4. Perform pre commit checks (using `pre_commit_instructions`).
-5. Submit the PR.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. Add explicit string replacement variables `{{.Tag}}` and `{{.Version}}` parsing to `actionvardoublequoted` and `ebuildvardoublequoted` functions in `generateWorkflows.go`.
+2. Ensure bash script inside `github-binary.tmpl`, `github-appimage.tmpl`, `github-cmake.tmpl`, `web-binary.tmpl`, and `web-appimage.tmpl` export the missing `${version}`, `${tag}` (as `TAG`) and `${originalVersion}` variables properly before constructing the `SRC_URI` block, so that it can be used inside `CustomDownloadUrl` or templates correctly (for `replace` calls).
+3. Validate fixes by testing template output with `go test -update-txtar ./...`.
+4. Perform pre commit checks (using `pre_commit_instructions`).
+5. Submit the PR.

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -111,6 +111,9 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -115,6 +115,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -78,6 +78,9 @@ jobs:
               echo "$tag / $version doesn't match gentoo version regexp; skipping"
               continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
 
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
               cmake_content=$(curl -sL "https://raw.githubusercontent.com/${{ env.github_owner }}/${{ env.github_repo }}/${tag}/CMakeLists.txt")

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -96,6 +96,10 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata [[ .G2MetadataArgs ]] "$metadata_file"
+
+          export VERSION="${version}"
+          export originalVersion="${version}"
+
           tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
             # shellcheck disable=SC2016
             {

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -119,6 +119,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -97,6 +97,9 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-appimage/custom_download_url.txtar
+++ b/testdata/txtar/github-appimage/custom_download_url.txtar
@@ -88,6 +88,9 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -92,6 +92,9 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -93,6 +93,9 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -96,6 +96,9 @@ jobs:
                 echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
+++ b/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
@@ -91,6 +91,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -92,6 +92,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -92,6 +92,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -94,6 +94,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-binary/issue74.txtar
+++ b/testdata/txtar/github-binary/issue74.txtar
@@ -95,6 +95,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -94,6 +94,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -77,6 +77,9 @@ jobs:
               echo "$tag / $version doesn't match gentoo version regexp; skipping"
               continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
               cmake_content=$(curl -sL "https://raw.githubusercontent.com/${{ env.github_owner }}/${{ env.github_repo }}/${tag}/CMakeLists.txt")
               qt6_components=$(echo "$cmake_content" | grep -i "find_package(Qt6" | tr '()' '  ' | sed 's/find_package  *Qt6//i' | tr -s ' ' '\n' | grep -ivE 'REQUIRED|COMPONENTS|CONFIG' | sort -u || true)

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -77,6 +77,9 @@ jobs:
               echo "$tag / $version doesn't match gentoo version regexp; skipping"
               continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
               cmake_content=$(curl -sL "https://raw.githubusercontent.com/${{ env.github_owner }}/${{ env.github_repo }}/${tag}/CMakeLists.txt")
               qt6_components=$(echo "$cmake_content" | grep -i "find_package(Qt6" | tr '()' '  ' | sed 's/find_package  *Qt6//i' | tr -s ' ' '\n' | grep -ivE 'REQUIRED|COMPONENTS|CONFIG' | sort -u || true)

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -97,6 +97,8 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata -m "maintainer@example.com:Example Maintainer:person" "$metadata_file"
+          export VERSION="${version}"
+          export originalVersion="${version}"
           tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
             # shellcheck disable=SC2016
             {

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -92,6 +92,8 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata -m "maintainer@example.com:Example Maintainer:person" "$metadata_file"
+          export VERSION="${version}"
+          export originalVersion="${version}"
           tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
             # shellcheck disable=SC2016
             {

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -96,6 +96,8 @@ jobs:
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
           g2 metadata -m "maintainer@example.com:Example Maintainer:person" "$metadata_file"
+          export VERSION="${version}"
+          export originalVersion="${version}"
           tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
             # shellcheck disable=SC2016
             {

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -107,6 +107,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -98,6 +98,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -103,6 +103,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -93,6 +93,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -105,6 +105,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -106,6 +106,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -97,6 +97,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/workarounds/issue88_example1.txtar
+++ b/testdata/txtar/workarounds/issue88_example1.txtar
@@ -92,6 +92,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/workarounds/issue88_example2.txtar
+++ b/testdata/txtar/workarounds/issue88_example2.txtar
@@ -91,6 +91,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -96,6 +96,9 @@ jobs:
                 echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
                 continue
             fi
+            export TAG="${tag}"
+            export VERSION="${version}"
+            export originalVersion="${originalVersion}"
             tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
 
               # shellcheck disable=SC2016


### PR DESCRIPTION
Fixes #97
Allows templated variables `{{.Tag}}` and `{{.Version}}` to be passed via the `Binary` configuration in `current.config` and expanded cleanly inside generated bash. 

Also exports `TAG`, `VERSION`, and `originalVersion` explicitly to the environment loop around ebuild rendering to ensure variables are available correctly in CustomDownloadUrl.

---
*PR created automatically by Jules for task [12376764919780748073](https://jules.google.com/task/12376764919780748073) started by @arran4*