### PR TITLE
Fix #98: Generator breaks Document extraction syntax with newdoc

### DIFF
--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -270,12 +270,20 @@ jobs:
         [[- if ne $docs.Keyword "" ]]
                 echo '    if use [[ $docs.Keyword ]]; then'
             [[- range $ii, $doc := $docs.Grouped ]]
+                [[- if eq $doc.SourceFilepath $doc.DestinationFilename ]]
+                echo '      dodoc "[[ $doc.SourceFilepath ]]" || die "Failed to install document [[ $doc.SourceFilepath ]]"'
+            [[- else ]]
                 echo '      newdoc "[[ $doc.SourceFilepath ]]" "[[ $doc.DestinationFilename ]]" || die "Failed to install document [[ $doc.DestinationFilename ]]"'
+            [[- end ]]
             [[ end ]]
                 echo '    fi'
         [[ else ]]
             [[- range $ii, $doc := $docs.Grouped ]]
+                [[- if eq $doc.SourceFilepath $doc.DestinationFilename ]]
+                echo '    dodoc "[[ $doc.SourceFilepath ]]" || die "Failed to install document [[ $doc.SourceFilepath ]]"'
+            [[- else ]]
                 echo '    newdoc "[[ $doc.SourceFilepath ]]" "[[ $doc.DestinationFilename ]]" || die "Failed to install document [[ $doc.DestinationFilename ]]"'
+            [[- end ]]
             [[ end ]]
         [[ end ]]
     [[ end ]]

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -274,12 +274,20 @@ jobs:
         [[- if ne $docs.Keyword "" ]]
                 echo '    if use [[ $docs.Keyword ]]; then'
             [[- range $ii, $doc := $docs.Grouped ]]
+                [[- if eq $doc.SourceFilepath $doc.DestinationFilename ]]
+                echo '      dodoc "[[ $doc.SourceFilepath ]]" || die "Failed to install document [[ $doc.SourceFilepath ]]"'
+            [[- else ]]
                 echo '      newdoc "[[ $doc.SourceFilepath ]]" "[[ $doc.DestinationFilename ]]" || die "Failed to install document [[ $doc.DestinationFilename ]]"'
+            [[- end ]]
             [[ end ]]
                 echo '    fi'
         [[ else ]]
             [[- range $ii, $doc := $docs.Grouped ]]
+                [[- if eq $doc.SourceFilepath $doc.DestinationFilename ]]
+                echo '    dodoc "[[ $doc.SourceFilepath ]]" || die "Failed to install document [[ $doc.SourceFilepath ]]"'
+            [[- else ]]
                 echo '    newdoc "[[ $doc.SourceFilepath ]]" "[[ $doc.DestinationFilename ]]" || die "Failed to install document [[ $doc.DestinationFilename ]]"'
+            [[- end ]]
             [[ end ]]
         [[ end ]]
     [[ end ]]

--- a/testdata/txtar/github-binary/issue98_dodoc.txtar
+++ b/testdata/txtar/github-binary/issue98_dodoc.txtar
@@ -1,0 +1,187 @@
+Test issue 98 dodoc output
+-- input.config --
+Type Github Binary Release
+GithubProjectUrl https://github.com/example/foo
+EbuildName foo-bin
+Category app-misc
+Description test
+License MIT
+ProgramName foo
+Binary amd64=>foo-${VERSION}.tar.gz > foo > foo
+Document amd64=>foo-${VERSION}.tar.gz > LICENSE.txt > LICENSE.txt
+Document amd64=>foo-${VERSION}.tar.gz > README.md > my-custom-readme.md
+
+-- expected.yaml --
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder 1.0.0 Github Binary Release test.config 2026-07-12 00:00:00 +0000 UTC
+
+name: app-misc/foo-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '24 2 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-misc-foo-bin-update.yaml'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ecn: app-misc
+  epn: foo-bin
+  description: "test"
+  homepage: ""
+  github_owner: example
+  github_repo: foo
+  keywords: ~amd64
+  workflow_filename: app-misc-foo-bin-update.yaml
+  foo_binary_installed_name: 'foo'
+  foo_binary_archived_name_amd64: 'foo'
+  foo_release_name_amd64: 'foo-${version}.tar.gz'
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/foo" --use-add "amd64:Enable amd64" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'SRC_URI="'
+                echo "	amd64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-foo-\${PV}.tar.gz  )  "
+                echo '"'
+                echo 'LICENSE="MIT"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo -n 'IUSE="'
+                echo -n ' doc'
+                echo -n ' amd64'
+                echo '"'
+                echo ''
+                echo -n 'REQUIRED_USE="'
+                echo '"'
+                echo ''
+                echo -n 'RDEPEND="'
+                echo '"'
+                echo ''
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-foo-\${PV}.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use amd64; then'
+                echo '    newexe "${{ env.foo_binary_archived_name_amd64 }}" "${{ env.foo_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use doc; then'
+                echo '    dodoc "LICENSE.txt" || die "Failed to install document LICENSE.txt"'
+                echo '    newdoc "README.md" "my-custom-readme.md" || die "Failed to install document my-custom-readme.md"'
+                echo '  fi'
+                echo '}'
+              } > "$tmp_ebuild_file"
+              next_ebuild_file=$(g2 ebuild next-revision "${ebuild_dir}/${{ env.epn }}-${version}" -inspect "$tmp_ebuild_file")
+              if [ $? -eq 0 ]; then
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-foo-${version}.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          g2 ebuild deduplicate "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles metadata
+          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
+          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
+          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
+          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+
+      - name: Lint output
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint -disable-rule PG0802 . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles metadata; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true; if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag


### PR DESCRIPTION
This PR resolves issue #98 by updating the document installation logic in the `github-binary.tmpl` and `web-binary.tmpl` templates.

When the source path matches the destination filename, the ebuild generation now emits `dodoc` instead of `newdoc` to prevent `pkgcheck` warnings about identical source and destination names. If the user explicitly provided a destination filename that differs from the source path, `newdoc` is still used.

Fixes #98

---
*PR created automatically by Jules for task [7299979616318922939](https://jules.google.com/task/7299979616318922939) started by @arran4*