### PR TITLE
Fix: skip linting when no new ebuilds are generated

### DIFF
--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -270,6 +270,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -326,6 +326,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -164,6 +164,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -205,6 +205,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -330,6 +330,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -207,6 +207,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-appimage/custom_download_url.txtar
+++ b/testdata/txtar/github-appimage/custom_download_url.txtar
@@ -160,6 +160,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -176,6 +176,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -181,6 +181,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -189,6 +189,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
+++ b/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
@@ -164,6 +164,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -165,6 +165,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -161,6 +161,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -164,6 +164,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/issue74.txtar
+++ b/testdata/txtar/github-binary/issue74.txtar
@@ -168,6 +168,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/issue98_dodoc.txtar
+++ b/testdata/txtar/github-binary/issue98_dodoc.txtar
@@ -170,6 +170,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -163,6 +163,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -162,6 +162,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -162,6 +162,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -185,6 +185,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -161,6 +161,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -164,6 +164,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -216,6 +216,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -167,6 +167,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -177,6 +177,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -163,6 +163,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -194,6 +194,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -195,6 +195,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -190,6 +190,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/workarounds/issue88_example1.txtar
+++ b/testdata/txtar/workarounds/issue88_example1.txtar
@@ -165,6 +165,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/workarounds/issue88_example2.txtar
+++ b/testdata/txtar/workarounds/issue88_example2.txtar
@@ -160,6 +160,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -169,6 +169,7 @@ jobs:
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
 
       - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2
         with:
           mode: 'run'


### PR DESCRIPTION
This PR reduces CI noise by skipping the `Lint output` step in the generated GitHub Actions workflows if no new ebuild was generated. It adds the appropriate conditional logic (`if: steps.process_releases.outputs.generated_tag` or `if: steps.find_appimage.outputs.version`) to all templates and updates the `.txtar` tests accordingly.

---
*PR created automatically by Jules for task [1726534575295696254](https://jules.google.com/task/1726534575295696254) started by @arran4*