### PR TITLE
ci: generate and test examples in CI for PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,16 @@ jobs:
           cache: true
       - name: Test
         run: go test ./... -v
+      - name: Check examples are up-to-date
+        run: |
+          if [[ -f examples/example.config ]]; then
+            mkdir -p examples/.github/workflows
+            go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/
+            if ! git diff --quiet examples/; then
+              echo "::error::Generated examples are out of sync. Please run 'go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/' and commit the changes."
+              exit 1
+            fi
+          fi
   go-vet:
     name: Go vet
     needs:
@@ -368,6 +378,13 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+      - name: Generate examples
+        if: ${{ needs.discover.outputs.has_go == 'true' }}
+        run: |
+          if [[ -f examples/example.config ]]; then
+            mkdir -p examples/.github/workflows
+            go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/
+          fi
       - name: Run autofix formatters
         shell: bash
         run: "set -euo pipefail\nif [[ \"${{ needs.discover.outputs.has_go }}\" ==\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,9 +305,9 @@ jobs:
         run: |
           if [[ -f examples/example.config ]]; then
             mkdir -p examples/.github/workflows
-            go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/
+            go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/ -force-date "2026-08-13 00:00:00 +0000 UTC"
             if ! git diff --quiet examples/; then
-              echo "::error::Generated examples are out of sync. Please run 'go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/' and commit the changes."
+              echo "::error::Generated examples are out of sync. Please run 'go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/ -force-date \"2026-08-13 00:00:00 +0000 UTC\"' and commit the changes."
               exit 1
             fi
           fi
@@ -383,7 +383,7 @@ jobs:
         run: |
           if [[ -f examples/example.config ]]; then
             mkdir -p examples/.github/workflows
-            go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/
+            go run cmd/generate/main.go generate workflows -input-file examples/example.config -output-dir examples/.github/workflows/ -force-date "2026-08-13 00:00:00 +0000 UTC"
           fi
       - name: Run autofix formatters
         shell: bash

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/arran4/arrans_overlay_workflow_builder"
 	"log"
 	"os"
+	"time"
 )
 
 var (
@@ -119,6 +120,7 @@ type CmdGenerateGithubWorkflowsArgConfig struct {
 	*CmdGenerateArgConfig
 	InputFile *string
 	OutputDir *string
+	ForceDate *string
 }
 
 func (mac *CmdGenerateArgConfig) cmdGenerateGithubWorkflows(args []string) error {
@@ -128,6 +130,7 @@ func (mac *CmdGenerateArgConfig) cmdGenerateGithubWorkflows(args []string) error
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	config.InputFile = fs.String("input-file", "input.config", "The input with config")
 	config.OutputDir = fs.String("output-dir", "./output", "Directory to output workflows")
+	config.ForceDate = fs.String("force-date", "", "Force a specific date (e.g. 2026-08-13 00:00:00 +0000 UTC) for testing")
 	if err := fs.Parse(args); err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
 	}
@@ -136,7 +139,18 @@ func (mac *CmdGenerateArgConfig) cmdGenerateGithubWorkflows(args []string) error
 		if config.InputFile == nil || *config.InputFile == "" {
 			return fmt.Errorf("input file argument missing")
 		}
-		return arrans_overlay_workflow_builder.GenerateGithubWorkflows(*config.InputFile, *config.OutputDir, config.Version)
+
+		var opts []any
+		if config.ForceDate != nil && *config.ForceDate != "" {
+			t, err := time.Parse("2006-01-02 15:04:05 -0700 MST", *config.ForceDate)
+			if err == nil {
+				opts = append(opts, t)
+			} else {
+				log.Printf("Warning: failed to parse force-date: %v. Expected format: '2006-01-02 15:04:05 -0700 MST'", err)
+			}
+		}
+
+		return arrans_overlay_workflow_builder.GenerateGithubWorkflows(*config.InputFile, *config.OutputDir, config.Version, opts...)
 	default:
 		log.Printf("Unknown command %s", fs.Arg(0))
 		os.Exit(-1)

--- a/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -1,0 +1,276 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release examples/example.config 2026-08-13 00:36:42.464694554 +0000 UTC m=+0.049494101
+
+name: app-admin/chezmoi-bin update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '31 12 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-admin-chezmoi-bin-update.yaml'
+
+env:
+  ecn: app-admin
+  epn: chezmoi-bin
+  description: "Manage your dotfiles across multiple diverse machines, securely."
+  homepage: "https://www.chezmoi.io/"
+  github_owner: twpayne
+  github_repo: chezmoi
+  keywords: ~amd64 ~arm ~arm64 ~ppc64 ~riscv ~s390 ~x86
+  workflow_filename: app-admin-chezmoi-bin-update.yaml
+  android_binary_installed_name: 'chezmoi'
+  android_binary_archived_name_arm64: 'chezmoi'
+  android_release_name_arm64: 'chezmoi_${version}_android_arm64.tar.gz'
+  chezmoi_binary_installed_name: 'chezmoi'
+  chezmoi_binary_archived_name_amd64: 'chezmoi'
+  chezmoi_release_name_amd64: 'chezmoi_${version}_linux-musl_amd64.tar.gz'
+  chezmoi_binary_archived_name_arm: 'chezmoi'
+  chezmoi_release_name_arm: 'chezmoi_${version}_linux_arm.tar.gz'
+  chezmoi_binary_archived_name_arm64: 'chezmoi'
+  chezmoi_release_name_arm64: 'chezmoi_${version}_linux_arm64.tar.gz'
+  chezmoi_binary_archived_name_ppc64: 'chezmoi'
+  chezmoi_release_name_ppc64: 'chezmoi_${version}_linux_ppc64.tar.gz'
+  chezmoi_binary_archived_name_riscv: 'chezmoi'
+  chezmoi_release_name_riscv: 'chezmoi_${version}_linux_riscv64.tar.gz'
+  chezmoi_binary_archived_name_s390: 'chezmoi'
+  chezmoi_release_name_s390: 'chezmoi_${version}_linux_s390x.tar.gz'
+  chezmoi_binary_archived_name_x86: 'chezmoi'
+  chezmoi_release_name_x86: 'chezmoi_${version}_linux_i386.tar.gz'
+  glibc_binary_installed_name: 'chezmoi'
+  glibc_binary_archived_name_amd64: 'chezmoi'
+  glibc_release_name_amd64: 'chezmoi_${version}_linux-glibc_amd64.tar.gz'
+  le_binary_installed_name: 'chezmoi'
+  le_binary_archived_name_ppc64: 'chezmoi'
+  le_release_name_ppc64: 'chezmoi_${version}_linux_ppc64le.tar.gz'
+  loong64_binary_installed_name: 'chezmoi'
+  loong64_binary_archived_name_amd64: 'chezmoi'
+  loong64_release_name_amd64: 'chezmoi_${version}_linux_loong64.tar.gz'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:twpayne/chezmoi" --use-add "amd64:Enable amd64" --use-add "android:Install android binary" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "glibc:Install glibc binary" --use-add "le:Install le binary" --use-add "loong64:Install loong64 binary" --use-add "ppc64:Enable ppc64" --use-add "riscv:Enable riscv" --use-add "s390:Enable s390" --use-add "x86:Enable x86" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "tag / $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                if [[ -v releaseTypes[release] ]]; then
+                  echo "Already have a newer main release: ${releaseTypes[release]}"
+                  continue
+                fi
+                releaseTypes[${releaseType:=release}]="${version}"
+            else
+                echo "Already have a newer ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'SRC_URI="'
+                echo "	amd64? ( glibc? ( !loong64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux-glibc_amd64.tar.gz  )  )  )  "
+                echo "	amd64? ( !glibc? ( !loong64? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux-musl_amd64.tar.gz  )  )  )  "
+                echo "	amd64? ( loong64? ( !glibc? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_loong64.tar.gz  )  )  )  "
+                echo "	arm? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_arm.tar.gz  )  "
+                echo "	arm64? ( android? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_android_arm64.tar.gz  )  )  "
+                echo "	arm64? ( !android? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_arm64.tar.gz  )  )  "
+                echo "	ppc64? ( !le? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_ppc64.tar.gz  )  )  "
+                echo "	ppc64? ( le? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_ppc64le.tar.gz  )  )  "
+                echo "	riscv? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_riscv64.tar.gz  )  "
+                echo "	s390? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_s390x.tar.gz  )  "
+                echo "	x86? (  https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-chezmoi_\${PV}_linux_i386.tar.gz  )  "
+                echo '"'
+                echo 'LICENSE="MIT License"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo -n 'IUSE="'
+                echo -n ' android glibc le loong64'
+                echo -n ' amd64 android arm arm64 glibc le loong64 ppc64 riscv s390 x86'
+                echo '"'
+                echo ''
+                echo -n 'REQUIRED_USE="'
+                echo -n 'android? ( || ( arm64  ) ) glibc? ( || ( amd64  ) ) le? ( || ( ppc64  ) ) loong64? ( || ( amd64  ) ) '
+                echo '"'
+                echo ''
+                echo -n 'RDEPEND="'
+                echo -n ''
+                echo '"'
+                echo ''
+                echo 'S="${WORKDIR}"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64 && use glibc && ! use loong64 ; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux-glibc_amd64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use amd64 && ! use glibc  && ! use loong64 ; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux-musl_amd64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use amd64 && use loong64 && ! use glibc ; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_loong64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_arm.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm64 && use android; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_android_arm64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use arm64 && ! use android ; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_arm64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use ppc64 && ! use le ; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_ppc64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use ppc64 && use le; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_ppc64le.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use riscv; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_riscv64.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use s390; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_s390x.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '  if use x86; then'
+                echo "    unpack \"\${DISTDIR}/\${P}-chezmoi_\${PV}_linux_i386.tar.gz\" || die \"Can't unpack archive file\""
+                echo '  fi'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  if use arm64 && use android; then'
+                echo '    newexe "${{ env.android_binary_archived_name_arm64 }}" "${{ env.android_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use amd64 && ! use glibc  && ! use loong64 ; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_amd64 }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_arm }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use arm64 && ! use android ; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_arm64 }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use ppc64 && ! use le ; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_ppc64 }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use riscv; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_riscv }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use s390; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_s390 }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use x86; then'
+                echo '    newexe "${{ env.chezmoi_binary_archived_name_x86 }}" "${{ env.chezmoi_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use amd64 && use glibc && ! use loong64 ; then'
+                echo '    newexe "${{ env.glibc_binary_archived_name_amd64 }}" "${{ env.glibc_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use ppc64 && use le; then'
+                echo '    newexe "${{ env.le_binary_archived_name_ppc64 }}" "${{ env.le_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '  if use amd64 && use loong64 && ! use glibc ; then'
+                echo '    newexe "${{ env.loong64_binary_archived_name_amd64 }}" "${{ env.loong64_binary_installed_name }}" || die "Failed to install Binary"'
+                echo '  fi'
+                echo '}'
+              } > "$tmp_ebuild_file"
+              if next_version=$(g2 ebuild next-revision --inspect "$tmp_ebuild_file" "${ebuild_dir}" "${version}"); then
+                  next_ebuild_file="${ebuild_dir}/${{ env.epn }}-${next_version}.ebuild"
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux-glibc_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux-musl_amd64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_loong64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_arm.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_android_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_arm64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_ppc64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_ppc64le.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_riscv64.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_s390x.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/${version}" "${{ env.epn }}-${version}-chezmoi_${version}_linux_i386.tar.gz" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          g2 ebuild deduplicate "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles metadata
+          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
+          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
+          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
+          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+
+      - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint -disable-rule PG0802 . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles metadata; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true; if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag

--- a/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release examples/example.config 2026-08-13 00:36:42.464694554 +0000 UTC m=+0.049494101
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github Binary Release examples/example.config 2026-08-13 00:00:00 +0000 UTC
 
 name: app-admin/chezmoi-bin update
 

--- a/examples/.github/workflows/app-text-anytype-ts-appimage-update.yaml
+++ b/examples/.github/workflows/app-text-anytype-ts-appimage-update.yaml
@@ -1,0 +1,184 @@
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release examples/example.config 2026-08-13 00:36:42.464694554 +0000 UTC m=+0.049494101
+
+name: app-text/anytype-ts-appimage update
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: '34 17 * * *'
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/app-text-anytype-ts-appimage-update.yaml'
+
+env:
+  ecn: app-text
+  epn: anytype-ts-appimage
+  description: "Official Anytype client for MacOS, Linux, and Windows"
+  homepage: "https://anytype.io"
+  github_owner: anyproto
+  github_repo: anytype-ts
+  keywords: ~amd64
+  workflow_filename: app-text-anytype-ts-appimage-update.yaml
+  Anytype_desktop_file: 'anytype.desktop'
+  Anytype_appimage_installed_name: 'Anytype.AppImage'
+  Anytype_release_name_amd64: 'Anytype-${version}.AppImage'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-and-create-ebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Install g2
+        uses: arran4/g2-action@v1.2
+
+      - name: Process each release
+        id: process_releases
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p "$ebuild_dir"
+          metadata_file="${ebuild_dir}/metadata.xml"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:anyproto/anytype-ts" "$metadata_file"
+          declare -A releaseTypes=()
+          tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
+          # shellcheck disable=SC2086
+          for tag in $tags; do
+            version="${tag#v}"
+            if [ "${version}" = "${tag}" ]; then
+                echo "$version == $tag so there is no v removed skipping"
+                continue
+            fi
+            # shellcheck disable=SC2034
+            originalVersion="${version}"
+            version="$(echo "${version}" | sed 's/^\([0-9]\+\(\.[0-9]\+\)*\)\(-r[0-9]*\)\?\([-_]\(alpha\|beta\|rc\|p\)\(\|\.\?\([0-9]\+\)\)\)$/\1_\5\3\7/')"
+            if ! echo "${version}" | grep -E '^([0-9]+)\.([0-9]+)(\.([0-9]+))?(-r[0-9]+)?((_)(alpha|beta|rc|p)[0-9]*)*$'; then
+                echo "version: $version doesn't match regexp";
+                continue;
+            fi
+            releaseType="$(echo "${version}" | sed -n 's/^[^_]\+_\(alpha\|beta\|rc\|p[0-9]*\).*$/\1/p')"
+            if [[ ! -v releaseTypes[${releaseType:=release}] ]]; then
+                releaseTypes[${releaseType:=release}]="$version"
+            else
+                echo "Already have a newier ${releaseType:=release} release: ${releaseTypes[${releaseType:=release}]}"
+                continue
+            fi
+            tmp_ebuild_file="${ebuild_dir}/${{ env.epn }}-${version}.ebuild.tmp"
+
+              # shellcheck disable=SC2016
+              {
+                echo '# Generated via: https://github.com/arran4/arrans_overlay/blob/main/.github/workflows/${{ env.workflow_filename }}'
+                echo 'EAPI=8'
+                echo "DESCRIPTION=\"${{ env.description }}\""
+                echo "HOMEPAGE=\"${{ env.homepage }}\""
+                echo 'LICENSE="Other"'
+                echo 'SLOT="0"'
+                echo 'KEYWORDS="${{ env.keywords }}"'
+                echo 'IUSE=""'
+                echo 'DEPEND=""'
+                echo 'RDEPEND="sys-fs/fuse:0 sys-libs/glibc sys-libs/zlib"'
+                echo 'S="${WORKDIR}"'
+                echo 'RESTRICT="strip"'
+                echo ''
+                echo "inherit xdg-utils"
+                echo ''
+                echo 'SRC_URI="'
+                echo "  amd64? ( https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${PV} -> \${P}-Anytype-\${PV}.AppImage )"
+                echo '"'
+                echo ''
+                echo 'src_unpack() {'
+                echo '  if use amd64; then'
+                echo "    cp \"\${DISTDIR}/\${P}-${{ env.Anytype_release_name_amd64 }}\" \"${{ env.Anytype_appimage_installed_name }}\"  || die \"Can't copy downloaded file\""
+                echo '  fi'
+                echo '  chmod a+x "${{ env.Anytype_appimage_installed_name }}"  || die "Can'\''t chmod archive file"'
+                echo '  "./${{ env.Anytype_appimage_installed_name }}" --appimage-extract "${{ env.Anytype_desktop_file }}" || die "Failed to extract .desktop from appimage"'
+                echo '  "./${{ env.Anytype_appimage_installed_name }}" --appimage-extract "usr/share/icons" || die "Failed to extract hicolor icons from app image"'
+                echo '  "./${{ env.Anytype_appimage_installed_name }}" --appimage-extract "*.png" || die "Failed to extract root icons from app image"'
+                echo '}'
+                echo ''
+                echo 'src_prepare() {'
+                echo "  sed -i 's:^Exec=.*:Exec=/opt/bin/${{ env.Anytype_appimage_installed_name }}:' 'squashfs-root/${{ env.Anytype_desktop_file }}'"
+                echo "  find squashfs-root -type f \( -name index.theme -or -name icon-theme.cache \) -exec rm {} \; "
+                echo "  find squashfs-root -type d -exec rmdir -p --ignore-fail-on-non-empty {} \; "
+                echo '  eapply_user'
+                echo '}'
+                echo ''
+                echo 'src_install() {'
+                echo '  exeinto /opt/bin'
+                echo '  doexe "${{ env.Anytype_appimage_installed_name }}" || die "Failed to install AppImage"'
+                echo '  insinto /usr/share/applications'
+                echo '  doins "squashfs-root/${{ env.Anytype_desktop_file }}" || die "Failed to install desktop file"'
+                echo '  insinto /usr/share/icons'
+                echo '  doins -r squashfs-root/usr/share/icons/hicolor || die "Failed to install icons"'
+                echo '  insinto /usr/share/pixmaps'
+                echo '  doins squashfs-root/*.png || die "Failed to install icons"'
+                echo '}'
+                echo ""
+                echo "pkg_postinst() {"
+                echo "  xdg_desktop_database_update"
+                echo "}"
+                echo ""
+
+              } > "$tmp_ebuild_file"
+              if next_version=$(g2 ebuild next-revision --inspect "$tmp_ebuild_file" "${ebuild_dir}" "${version}"); then
+                  next_ebuild_file="${ebuild_dir}/${{ env.epn }}-${next_version}.ebuild"
+                  echo "Content changed or new version for $version. Writing $next_ebuild_file"
+                  mv "$tmp_ebuild_file" "$next_ebuild_file"
+                  ebuild_file="$next_ebuild_file"
+              else
+                  echo "Matches existing ebuild. Skipping."
+                  rm -f "$tmp_ebuild_file"
+                  continue
+              fi
+              failed=0
+              if ! g2 manifest upsert-from-url "https://github.com/${{ env.github_owner }}/${{ env.github_repo }}/releases/download/${tag}/\${P}" "${{ env.epn }}-${version}-Anytype-${version}.AppImage" "${ebuild_dir}/Manifest"; then failed=1; fi
+              if [ "$failed" -eq 1 ]; then
+                  echo "Failed to generate manifest for $tag. Skipping..."
+                  rm -f "$ebuild_file"
+                  continue
+              fi
+              echo "generated_tag=${tag}" >> $GITHUB_OUTPUT
+          done
+
+      - name: Deduplicate ebuilds
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          g2 ebuild deduplicate "${ebuild_dir}"
+
+      - name: Generate Overlay
+        run: |
+          mkdir -p profiles metadata
+          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
+          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
+          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
+          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+
+      - name: Lint output
+        if: steps.process_releases.outputs.generated_tag
+        uses: arran4/g2-action@v1.2
+        with:
+          mode: 'run'
+          action: 'lint -disable-rule PG0802 . ${{ env.ecn }}/${{ env.epn }}'
+
+      - name: Commit and push changes
+        run: |
+          ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
+          mkdir -p profiles metadata; [ ! -f profiles/repo_name ] && echo "${{ env.github_repo }}" > profiles/repo_name; [ ! -f profiles/eapi ] && echo "8" > profiles/eapi; [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true; if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi; g2 cache generate "${{ env.ecn }}/${{ env.epn }}"
+          git add "./${ebuild_dir}"
+          if git commit -m "Add ebuilds for new ${{ env.epn }} releases tag ${generated_tag}"; then
+            git pull --rebase &&
+            git push
+          fi || true
+        if: steps.process_releases.outputs.generated_tag

--- a/examples/.github/workflows/app-text-anytype-ts-appimage-update.yaml
+++ b/examples/.github/workflows/app-text-anytype-ts-appimage-update.yaml
@@ -1,4 +1,4 @@
-# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release examples/example.config 2026-08-13 00:36:42.464694554 +0000 UTC m=+0.049494101
+# Generated using: https://github.com/arran4/arrans_overlay_workflow_builder dev Github AppImage Release examples/example.config 2026-08-13 00:00:00 +0000 UTC
 
 name: app-text/anytype-ts-appimage update
 

--- a/examples/example.config
+++ b/examples/example.config
@@ -1,0 +1,40 @@
+Type Github AppImage Release
+GithubProjectUrl https://github.com/anyproto/anytype-ts
+Category app-text
+EbuildName anytype-ts-appimage
+Description Official Anytype client for MacOS, Linux, and Windows
+Workaround Semantic Version Prerelease Hack 1
+Homepage https://anytype.io
+License Other
+ProgramName Anytype
+DesktopFile anytype.desktop
+Icons hicolor-apps root
+Dependencies sys-libs/glibc sys-libs/zlib
+Binary amd64=>Anytype-${VERSION}.AppImage > Anytype.AppImage
+
+Type Github Binary Release
+GithubProjectUrl https://github.com/twpayne/chezmoi
+EbuildName chezmoi-bin
+Category app-admin
+Description Manage your dotfiles across multiple diverse machines, securely.
+Homepage https://www.chezmoi.io/
+License MIT License
+Workaround Programs as Alternatives => amd64:glibc amd64:loong64 arm64:android ppc64:le
+ProgramName android
+Binary arm64=>chezmoi_${VERSION}_android_arm64.tar.gz > chezmoi > chezmoi
+ProgramName chezmoi
+Dependencies sys-libs/glibc
+Binary amd64=>chezmoi_${VERSION}_linux-musl_amd64.tar.gz > chezmoi > chezmoi
+Binary arm=>chezmoi_${VERSION}_linux_arm.tar.gz > chezmoi > chezmoi
+Binary arm64=>chezmoi_${VERSION}_linux_arm64.tar.gz > chezmoi > chezmoi
+Binary ppc64=>chezmoi_${VERSION}_linux_ppc64.tar.gz > chezmoi > chezmoi
+Binary riscv=>chezmoi_${VERSION}_linux_riscv64.tar.gz > chezmoi > chezmoi
+Binary s390=>chezmoi_${VERSION}_linux_s390x.tar.gz > chezmoi > chezmoi
+Binary x86=>chezmoi_${VERSION}_linux_i386.tar.gz > chezmoi > chezmoi
+ProgramName glibc
+Dependencies sys-libs/glibc
+Binary amd64=>chezmoi_${VERSION}_linux-glibc_amd64.tar.gz > chezmoi > chezmoi
+ProgramName le
+Binary ppc64=>chezmoi_${VERSION}_linux_ppc64le.tar.gz > chezmoi > chezmoi
+ProgramName loong64
+Binary amd64=>chezmoi_${VERSION}_linux_loong64.tar.gz > chezmoi > chezmoi


### PR DESCRIPTION
This patch updates the CI configuration to ensure that a variety of example configurations (e.g., Github AppImage, Github Binary) are generated into an `examples/.github/workflows` folder.

This allows deployments and generated outputs to be easily tested and verified within a Pull Request without needing to apply it against the live repository overlay.
- Added `examples/example.config` featuring multiple types of configurations.
- Added a generation step in `.github/workflows/ci.yml` under the `autofix` job.
- Added a verification check under the `go-test` job in `ci.yml` that fails if the generated examples are out of sync.

Fixes #108

---
*PR created automatically by Jules for task [118597047371337405](https://jules.google.com/task/118597047371337405) started by @arran4*