### PR TITLE
feat: make Generate Overlay step optional

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -37,18 +37,20 @@ func main() {
 	}
 	var globalGenerateMd5Cache bool
 	// A workaround for global flags being parsed before the command is parsed
+	var globalGenerateOverlay bool
 	for i, arg := range os.Args {
 		if arg == "--generate-md5-cache" || arg == "-generate-md5-cache" {
 			globalGenerateMd5Cache = true
 			os.Args = append(os.Args[:i], os.Args[i+1:]...)
 			break
 		} else if arg == "--generate-overlay" || arg == "-generate-overlay" {
-			arrans_overlay_workflow_builder.GenerateOverlayGlobal = true
+			globalGenerateOverlay = true
 			os.Args = append(os.Args[:i], os.Args[i+1:]...)
 			break
 		}
 	}
 	arrans_overlay_workflow_builder.GenerateMd5CacheGlobal = globalGenerateMd5Cache
+	arrans_overlay_workflow_builder.GenerateOverlayGlobal = globalGenerateOverlay
 
 	if err := fs.Parse(os.Args); err != nil {
 		log.Printf("Flag parse error: %s", err)

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -42,6 +42,10 @@ func main() {
 			globalGenerateMd5Cache = true
 			os.Args = append(os.Args[:i], os.Args[i+1:]...)
 			break
+		} else if arg == "--generate-overlay" || arg == "-generate-overlay" {
+			arrans_overlay_workflow_builder.GenerateOverlayGlobal = true
+			os.Args = append(os.Args[:i], os.Args[i+1:]...)
+			break
 		}
 	}
 	arrans_overlay_workflow_builder.GenerateMd5CacheGlobal = globalGenerateMd5Cache

--- a/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -249,14 +249,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/examples/.github/workflows/app-text-anytype-ts-appimage-update.yaml
+++ b/examples/.github/workflows/app-text-anytype-ts-appimage-update.yaml
@@ -157,14 +157,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -466,3 +466,7 @@ func (b *GenerateGithubWorkflowBase) WorkaroundGentooVersionRegularExpression() 
 func (b *GenerateGithubWorkflowBase) FeatureGenerateMd5Cache() bool {
 	return b.InputConfig.FeatureGenerateMd5Cache()
 }
+
+func (b *GenerateGithubWorkflowBase) FeatureGenerateOverlay() bool {
+	return b.InputConfig.FeatureGenerateOverlay()
+}

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -1259,3 +1259,11 @@ func (ic *InputConfig) FeatureGenerateMd5Cache() bool {
 }
 
 var GenerateMd5CacheGlobal = false
+
+func (ic *InputConfig) FeatureGenerateOverlay() bool {
+	if ic.Features == nil {
+		return false
+	}
+	_, ok := ic.Features["Generate Overlay"]
+	return ok
+}

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -1265,5 +1265,7 @@ func (ic *InputConfig) FeatureGenerateOverlay() bool {
 		return false
 	}
 	_, ok := ic.Features["Generate Overlay"]
-	return ok
+	return ok || GenerateOverlayGlobal
 }
+
+var GenerateOverlayGlobal = false

--- a/templates/github-appimage.tmpl
+++ b/templates/github-appimage.tmpl
@@ -261,6 +261,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
+[[- if .FeatureGenerateOverlay ]]
       - name: Generate Overlay
         run: |
           mkdir -p profiles metadata
@@ -268,6 +269,7 @@ jobs:
           [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
           [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+[[- end ]]
 
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag

--- a/templates/github-binary.tmpl
+++ b/templates/github-binary.tmpl
@@ -317,6 +317,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
+[[- if .FeatureGenerateOverlay ]]
       - name: Generate Overlay
         run: |
           mkdir -p profiles metadata
@@ -324,6 +325,7 @@ jobs:
           [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
           [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+[[- end ]]
 
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag

--- a/templates/github-cmake.tmpl
+++ b/templates/github-cmake.tmpl
@@ -155,6 +155,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
+[[- if .FeatureGenerateOverlay ]]
       - name: Generate Overlay
         run: |
           mkdir -p profiles metadata
@@ -162,6 +163,7 @@ jobs:
           [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
           [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+[[- end ]]
 
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag

--- a/templates/web-appimage.tmpl
+++ b/templates/web-appimage.tmpl
@@ -196,6 +196,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
+[[- if .FeatureGenerateOverlay ]]
       - name: Generate Overlay
         run: |
           mkdir -p profiles metadata
@@ -203,6 +204,7 @@ jobs:
           [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
           [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+[[- end ]]
 
       - name: Lint output
         if: steps.find_appimage.outputs.version

--- a/templates/web-binary.tmpl
+++ b/templates/web-binary.tmpl
@@ -321,6 +321,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
+[[- if .FeatureGenerateOverlay ]]
       - name: Generate Overlay
         run: |
           mkdir -p profiles metadata
@@ -328,6 +329,7 @@ jobs:
           [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
           [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
           if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
+[[- end ]]
 
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag

--- a/testdata/txtar/github-appimage/check_asset_size.txtar
+++ b/testdata/txtar/github-appimage/check_asset_size.txtar
@@ -198,14 +198,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-appimage/custom_download_url.txtar
+++ b/testdata/txtar/github-appimage/custom_download_url.txtar
@@ -151,14 +151,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-appimage/custom_version_source.txtar
+++ b/testdata/txtar/github-appimage/custom_version_source.txtar
@@ -167,14 +167,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-appimage/localsend.txtar
+++ b/testdata/txtar/github-appimage/localsend.txtar
@@ -172,14 +172,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-appimage/rustdesk.txtar
+++ b/testdata/txtar/github-appimage/rustdesk.txtar
@@ -180,14 +180,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
+++ b/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
@@ -155,14 +155,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -156,14 +156,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -152,14 +152,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -155,14 +155,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/issue74.txtar
+++ b/testdata/txtar/github-binary/issue74.txtar
@@ -159,14 +159,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/issue98_dodoc.txtar
+++ b/testdata/txtar/github-binary/issue98_dodoc.txtar
@@ -161,14 +161,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -154,14 +154,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-cmake/kllamabooks-regex.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks-regex.txtar
@@ -153,14 +153,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/github-cmake/kllamabooks.txtar
+++ b/testdata/txtar/github-cmake/kllamabooks.txtar
@@ -153,14 +153,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-appimage/check_asset_size.txtar
+++ b/testdata/txtar/web-appimage/check_asset_size.txtar
@@ -176,14 +176,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-appimage/custom_version_source.txtar
+++ b/testdata/txtar/web-appimage/custom_version_source.txtar
@@ -152,14 +152,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-appimage/example.txtar
+++ b/testdata/txtar/web-appimage/example.txtar
@@ -155,14 +155,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.find_appimage.outputs.version
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -207,14 +207,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -158,14 +158,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -168,14 +168,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -154,14 +154,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -185,14 +185,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -186,14 +186,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -181,14 +181,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/workarounds/issue88_example1.txtar
+++ b/testdata/txtar/workarounds/issue88_example1.txtar
@@ -156,14 +156,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/workarounds/issue88_example2.txtar
+++ b/testdata/txtar/workarounds/issue88_example2.txtar
@@ -151,14 +151,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -160,14 +160,6 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           g2 ebuild deduplicate "${ebuild_dir}"
 
-      - name: Generate Overlay
-        run: |
-          mkdir -p profiles metadata
-          [ ! -f profiles/repo_name ] && echo "overlay_name" > profiles/repo_name
-          [ ! -f profiles/eapi ] && echo "8" > profiles/eapi
-          [ ! -f metadata/layout.conf ] && wget -qO - https://raw.githubusercontent.com/gentoo/gentoo/master/metadata/layout.conf > metadata/layout.conf || true
-          if ! grep -q "^cache-formats" metadata/layout.conf; then echo "cache-formats = md5-dict" >> metadata/layout.conf; else echo "::warning title=Layout.conf check::cache-formats is already defined in layout.conf, skipping generation."; fi
-
       - name: Lint output
         if: steps.process_releases.outputs.generated_tag
         uses: arran4/g2-action@v1.2


### PR DESCRIPTION
Added `FeatureGenerateOverlay` method to `InputConfig` and `GenerateGithubWorkflowBase`.
Wrapped `Generate Overlay` step in `templates/*.tmpl` with `[[- if .FeatureGenerateOverlay ]]` condition.
Regenerated `txtar` test files to reflect the omission of this step by default.

---
*PR created automatically by Jules for task [4058273761618161049](https://jules.google.com/task/4058273761618161049) started by @arran4*