### PR TITLE
Fix architectures leaking to IUSE

### DIFF
--- a/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
+++ b/examples/.github/workflows/app-admin-chezmoi-bin-update.yaml
@@ -75,7 +75,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:twpayne/chezmoi" --use-add "amd64:Enable amd64" --use-add "android:Install android binary" --use-add "arm:Enable arm" --use-add "arm64:Enable arm64" --use-add "glibc:Install glibc binary" --use-add "le:Install le binary" --use-add "loong64:Install loong64 binary" --use-add "ppc64:Enable ppc64" --use-add "riscv:Enable riscv" --use-add "s390:Enable s390" --use-add "x86:Enable x86" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:twpayne/chezmoi" --use-add "android:Install android binary" --use-add "glibc:Install glibc binary" --use-add "le:Install le binary" --use-add "loong64:Install loong64 binary" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -128,7 +128,7 @@ jobs:
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
                 echo -n ' android glibc le loong64'
-                echo -n ' amd64 android arm arm64 glibc le loong64 ppc64 riscv s390 x86'
+                echo -n ' android glibc le loong64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/generateGithubAppImageWorkflow.go
+++ b/generateGithubAppImageWorkflow.go
@@ -19,7 +19,13 @@ func (ggaitd *GenerateGithubAppImageTemplateData) KeywordList() []string {
 	keywords := make([]string, 0)
 	for programName := range ggaitd.Programs {
 		for key := range ggaitd.Programs[programName].Binary {
-			keywords = append(keywords, key)
+			kw := key
+			if start := strings.Index(key, "["); start != -1 {
+				if end := strings.LastIndex(key, "]"); end != -1 && end > start {
+					kw = key[:start]
+				}
+			}
+			keywords = append(keywords, kw)
 		}
 	}
 	sort.Strings(keywords)

--- a/generateGithubBinaryWorkflow.go
+++ b/generateGithubBinaryWorkflow.go
@@ -33,7 +33,8 @@ func (ggbtd *GenerateGithubBinaryTemplateData) KeywordList() []string {
 	keywords := make([]string, 0)
 	for programName := range ggbtd.Programs {
 		for key := range ggbtd.Programs[programName].Binary {
-			keywords = append(keywords, key)
+			kw, _, _ := ggbtd.ParseKeywordAndUseFlags(key)
+			keywords = append(keywords, kw)
 		}
 	}
 	sort.Strings(keywords)
@@ -469,17 +470,22 @@ func (ggbtd *GenerateGithubBinaryTemplateData) inferUseFlags() {
 func (ggbtd *GenerateGithubBinaryTemplateData) ExtractedUseFlags() []string {
 	ggbtd.inferUseFlags()
 	flagsSet := make(map[string]struct{})
+	keywordList := ggbtd.KeywordList()
 	for _, progMap := range ggbtd.MustHaveUseFlags {
 		for _, flags := range progMap {
 			for _, f := range flags {
-				flagsSet[f] = struct{}{}
+				if !slices.Contains(keywordList, f) {
+					flagsSet[f] = struct{}{}
+				}
 			}
 		}
 	}
 	for _, progMap := range ggbtd.MustntHaveUseFlags {
 		for _, flags := range progMap {
 			for _, f := range flags {
-				flagsSet[f] = struct{}{}
+				if !slices.Contains(keywordList, f) {
+					flagsSet[f] = struct{}{}
+				}
 			}
 		}
 	}

--- a/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
+++ b/testdata/txtar/github-binary/binary-archived-name-quoting.txtar
@@ -64,7 +64,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:derailed/k9s" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:derailed/k9s" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -106,7 +106,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/github-binary/binary-replacement.txtar
+++ b/testdata/txtar/github-binary/binary-replacement.txtar
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:derailed/k9s" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:derailed/k9s" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -107,7 +107,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/github-binary/custom_download_url.txtar
+++ b/testdata/txtar/github-binary/custom_download_url.txtar
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/example" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/example" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -107,7 +107,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/github-binary/custom_version_source.txtar
+++ b/testdata/txtar/github-binary/custom_version_source.txtar
@@ -67,7 +67,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/example" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/example" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(echo "v1.2.3")
           # shellcheck disable=SC2086
@@ -109,7 +109,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/github-binary/issue74.txtar
+++ b/testdata/txtar/github-binary/issue74.txtar
@@ -67,7 +67,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:derailed/k9s" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:derailed/k9s" "$metadata_file"
           declare -A releaseTypes=()
           echo "Pre version steps test with TAG=${tag} and VERSION=${version}"
           tags=$(echo "${tag}" | sed 's/v//')
@@ -110,7 +110,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/github-binary/issue98_dodoc.txtar
+++ b/testdata/txtar/github-binary/issue98_dodoc.txtar
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/foo" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:example/foo" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -108,7 +108,6 @@ jobs:
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
                 echo -n ' doc'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/github-binary/revision.txtar
+++ b/testdata/txtar/github-binary/revision.txtar
@@ -67,7 +67,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "test@example.com:Test Maintainer:person" -u "github:example/tool" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "test@example.com:Test Maintainer:person" -u "github:example/tool" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -109,7 +109,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/web-binary/check_asset_size.txtar
+++ b/testdata/txtar/web-binary/check_asset_size.txtar
@@ -74,7 +74,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" "$metadata_file"
           declare -A releaseTypes=()
           if [ -z "curl -s -L https://cloud.google.com/sdk/docs/release-notes | grep -m 1 -oE 'data-text="[0-9]+\.[0-9]+\.[0-9]+' | cut -d '"' -f 2" ]; then
              echo "TagsCommand is required for Web Binary configurations" >&2
@@ -124,7 +124,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64 arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/web-binary/custom_download_url.txtar
+++ b/testdata/txtar/web-binary/custom_download_url.txtar
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" "$metadata_file"
           declare -A releaseTypes=()
           if [ -z "curl -s https://example.com/tags | jq -r .[]" ]; then
              echo "TagsCommand is required for Web Binary configurations" >&2
@@ -113,7 +113,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/web-binary/custom_full.txtar
+++ b/testdata/txtar/web-binary/custom_full.txtar
@@ -69,7 +69,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" "$metadata_file"
           declare -A releaseTypes=()
           echo "Fetching RSS feed to extract latest tag" > /tmp/log
           if [ -z "curl -sL https://example.com/feed.xml | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*'" ]; then
@@ -118,7 +118,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/web-binary/custom_version_source.txtar
+++ b/testdata/txtar/web-binary/custom_version_source.txtar
@@ -64,7 +64,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(echo "v1.2.3")
           # shellcheck disable=SC2086
@@ -108,7 +108,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/web-binary/web-binary-regex.txtar
+++ b/testdata/txtar/web-binary/web-binary-regex.txtar
@@ -72,7 +72,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" "$metadata_file"
           declare -A releaseTypes=()
           if [ -z "curl -s -L https://cloud.google.com/sdk/docs/release-notes | grep -m 1 -oE 'data-text="[0-9]+\.[0-9]+\.[0-9]+' | cut -d '"' -f 2" ]; then
              echo "TagsCommand is required for Web Binary configurations" >&2
@@ -122,7 +122,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64 arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/web-binary/web-binary.txtar
+++ b/testdata/txtar/web-binary/web-binary.txtar
@@ -73,7 +73,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" --use-add "amd64:Enable amd64" --use-add "arm64:Enable arm64" --use-add "x86:Enable x86" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" "$metadata_file"
           declare -A releaseTypes=()
           if [ -z "curl -s -L https://cloud.google.com/sdk/docs/release-notes | grep -m 1 -oE 'data-text="[0-9]+\.[0-9]+\.[0-9]+' | cut -d '"' -f 2" ]; then
              echo "TagsCommand is required for Web Binary configurations" >&2
@@ -123,7 +123,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64 arm64 x86'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/workarounds/check_asset_size.txtar
+++ b/testdata/txtar/workarounds/check_asset_size.txtar
@@ -73,7 +73,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rustdesk/rustdesk" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rustdesk/rustdesk" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -112,7 +112,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/workarounds/issue88_example1.txtar
+++ b/testdata/txtar/workarounds/issue88_example1.txtar
@@ -65,7 +65,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:probonopd/go-appimage" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:probonopd/go-appimage" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -107,7 +107,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/workarounds/issue88_example2.txtar
+++ b/testdata/txtar/workarounds/issue88_example2.txtar
@@ -64,7 +64,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rust-lang/rust" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rust-lang/rust" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -106,7 +106,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'

--- a/testdata/txtar/workarounds/rustdesk.txtar
+++ b/testdata/txtar/workarounds/rustdesk.txtar
@@ -72,7 +72,7 @@ jobs:
           ebuild_dir="./${{ env.ecn }}/${{ env.epn }}"
           mkdir -p "$ebuild_dir"
           metadata_file="${ebuild_dir}/metadata.xml"
-          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rustdesk/rustdesk" --use-add "amd64:Enable amd64" "$metadata_file"
+          g2 metadata -m "gentoo@arran4.com:Arran Ubels:person" -u "github:rustdesk/rustdesk" "$metadata_file"
           declare -A releaseTypes=()
           tags=$(GH_TOKEN="${{secrets.GITHUB_TOKEN}}" gh api "repos/${{ env.github_owner }}/${{ env.github_repo }}/releases" --jq '.[]? | select(type=="object" and has("tag_name")) | .tag_name')
           # shellcheck disable=SC2086
@@ -111,7 +111,6 @@ jobs:
                 echo 'SLOT="0"'
                 echo 'KEYWORDS="${{ env.keywords }}"'
                 echo -n 'IUSE="'
-                echo -n ' amd64'
                 echo '"'
                 echo ''
                 echo -n 'REQUIRED_USE="'


### PR DESCRIPTION
This fixes an issue where architectures parsed from binaries (like amd64, arm) were incorrectly added to `IUSE` and USE flags.

Architecture keywords were appended to `IUSE` because they were matched inside `ExtractedUseFlags`. We now ensure we strip any flags in `IUSE` that are also present in `KeywordList`. We also updated `KeywordList()` to return correctly processed architectures.

---
*PR created automatically by Jules for task [9895270201025736388](https://jules.google.com/task/9895270201025736388) started by @arran4*