### PR TITLE
Refactor to remove GenerateMd5Cache and GenerateOverlay global variables

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -16,11 +16,11 @@ var (
 )
 
 type MainArgConfig struct {
-	Version            string
-	Commit             string
-	Date               string
-	GenerateMd5Cache   bool
-	GenerateOverlay    bool
+	Version          string
+	Commit           string
+	Date             string
+	GenerateMd5Cache bool
+	GenerateOverlay  bool
 }
 
 func valueOrDefault(v *string) string {
@@ -46,11 +46,12 @@ func main() {
 	}
 	for i := 1; i < len(os.Args); i++ {
 		arg := os.Args[i]
-		if arg == "--generate-md5-cache" || arg == "-generate-md5-cache" {
+		switch arg {
+		case "--generate-md5-cache", "-generate-md5-cache":
 			globalGenerateMd5Cache = true
-		} else if arg == "--generate-overlay" || arg == "-generate-overlay" {
+		case "--generate-overlay", "-generate-overlay":
 			globalGenerateOverlay = true
-		} else {
+		default:
 			newArgs = append(newArgs, arg)
 		}
 	}

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -16,9 +16,11 @@ var (
 )
 
 type MainArgConfig struct {
-	Version string
-	Commit  string
-	Date    string
+	Version            string
+	Commit             string
+	Date               string
+	GenerateMd5Cache   bool
+	GenerateOverlay    bool
 }
 
 func valueOrDefault(v *string) string {
@@ -38,19 +40,23 @@ func main() {
 	var globalGenerateMd5Cache bool
 	// A workaround for global flags being parsed before the command is parsed
 	var globalGenerateOverlay bool
-	for i, arg := range os.Args {
+	var newArgs []string
+	if len(os.Args) > 0 {
+		newArgs = append(newArgs, os.Args[0])
+	}
+	for i := 1; i < len(os.Args); i++ {
+		arg := os.Args[i]
 		if arg == "--generate-md5-cache" || arg == "-generate-md5-cache" {
 			globalGenerateMd5Cache = true
-			os.Args = append(os.Args[:i], os.Args[i+1:]...)
-			break
 		} else if arg == "--generate-overlay" || arg == "-generate-overlay" {
 			globalGenerateOverlay = true
-			os.Args = append(os.Args[:i], os.Args[i+1:]...)
-			break
+		} else {
+			newArgs = append(newArgs, arg)
 		}
 	}
-	arrans_overlay_workflow_builder.GenerateMd5CacheGlobal = globalGenerateMd5Cache
-	arrans_overlay_workflow_builder.GenerateOverlayGlobal = globalGenerateOverlay
+	os.Args = newArgs
+	config.GenerateMd5Cache = globalGenerateMd5Cache
+	config.GenerateOverlay = globalGenerateOverlay
 
 	if err := fs.Parse(os.Args); err != nil {
 		log.Printf("Flag parse error: %s", err)
@@ -154,6 +160,12 @@ func (mac *CmdGenerateArgConfig) cmdGenerateGithubWorkflows(args []string) error
 			} else {
 				log.Printf("Warning: failed to parse force-date: %v. Expected format: '2006-01-02 15:04:05 -0700 MST'", err)
 			}
+		}
+		if config.GenerateMd5Cache {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateMd5Cache(true))
+		}
+		if config.GenerateOverlay {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateOverlay(true))
 		}
 
 		return arrans_overlay_workflow_builder.GenerateGithubWorkflows(*config.InputFile, *config.OutputDir, config.Version, opts...)
@@ -538,7 +550,14 @@ func (mac *CmdOneshotArgConfig) cmdOneshotGithubReleaseAppImage(args []string) e
 		if config.GithubUrl == nil || *config.GithubUrl == "" {
 			return fmt.Errorf("github URL to view is missing")
 		}
-		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseAppImage(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version)
+		var opts []any
+		if config.GenerateMd5Cache {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateMd5Cache(true))
+		}
+		if config.GenerateOverlay {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateOverlay(true))
+		}
+		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseAppImage(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version, opts...)
 	default:
 		log.Printf("Unknown command %s", fs.Arg(0))
 		os.Exit(-1)
@@ -571,7 +590,14 @@ func (mac *CmdOneshotArgConfig) cmdOneshotGithubReleaseBinary(args []string) err
 		if config.GithubUrl == nil || *config.GithubUrl == "" {
 			return fmt.Errorf("github URL to view is missing")
 		}
-		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseBinary(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version)
+		var opts []any
+		if config.GenerateMd5Cache {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateMd5Cache(true))
+		}
+		if config.GenerateOverlay {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateOverlay(true))
+		}
+		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseBinary(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version, opts...)
 	default:
 		log.Printf("Unknown command %s", fs.Arg(0))
 		os.Exit(-1)
@@ -602,7 +628,14 @@ func (mac *CmdOneshotArgConfig) cmdOneshotWebAppImage(args []string) error {
 		if config.PageUrl == nil || *config.PageUrl == "" {
 			return fmt.Errorf("url missing")
 		}
-		return arrans_overlay_workflow_builder.CmdOneshotWebAppImage(*config.PageUrl, *config.MatchExpr, valueOrDefault(config.Extension), *config.OutputDir, config.Version)
+		var opts []any
+		if config.GenerateMd5Cache {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateMd5Cache(true))
+		}
+		if config.GenerateOverlay {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateOverlay(true))
+		}
+		return arrans_overlay_workflow_builder.CmdOneshotWebAppImage(*config.PageUrl, *config.MatchExpr, valueOrDefault(config.Extension), *config.OutputDir, config.Version, opts...)
 	default:
 		log.Printf("Unknown command %s", fs.Arg(0))
 		os.Exit(-1)
@@ -704,7 +737,14 @@ func (mac *CmdOneshotArgConfig) cmdOneshotGithubReleaseCmakeSource(args []string
 		if config.GithubUrl == nil || *config.GithubUrl == "" {
 			return fmt.Errorf("github URL to view is missing")
 		}
-		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseCmakeSource(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version)
+		var opts []any
+		if config.GenerateMd5Cache {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateMd5Cache(true))
+		}
+		if config.GenerateOverlay {
+			opts = append(opts, arrans_overlay_workflow_builder.OptGenerateOverlay(true))
+		}
+		return arrans_overlay_workflow_builder.CmdOneshotGithubReleaseCmakeSource(*config.GithubUrl, *config.SelectedVersionTag, *config.TagPrefix, *config.OutputDir, config.Version, opts...)
 	default:
 		log.Printf("Unknown command %s", fs.Arg(0))
 		os.Exit(-1)

--- a/generateGithubCmakeSourceWorkflow.go
+++ b/generateGithubCmakeSourceWorkflow.go
@@ -33,7 +33,7 @@ func ConfigViewCmakeSourceGithubReleases(githubUrl string, selectedVersionTag st
 	return err
 }
 
-func CmdOneshotGithubReleaseCmakeSource(githubUrl string, selectedVersionTag string, tagPrefix string, outputDir string, version string) error {
+func CmdOneshotGithubReleaseCmakeSource(githubUrl string, selectedVersionTag string, tagPrefix string, outputDir string, version string, opts ...any) error {
 	repoName, ic, versions, tags, releaseInfo, _, err := NewInputConfigurationFromRepo(githubUrl, selectedVersionTag, tagPrefix, "", "Github Cmake Release")
 	if err != nil {
 		return err
@@ -44,5 +44,5 @@ func CmdOneshotGithubReleaseCmakeSource(githubUrl string, selectedVersionTag str
 	_ = releaseInfo
 
 	log.Printf("Generating from repo")
-	return GenerateGithubWorkflowsFromInputConfigs("oneshot", []*InputConfig{ic}, outputDir, version)
+	return GenerateGithubWorkflowsFromInputConfigs("oneshot", []*InputConfig{ic}, outputDir, version, opts...)
 }

--- a/generateWorkflows.go
+++ b/generateWorkflows.go
@@ -309,12 +309,18 @@ func ParseWorkflowTemplates() (*template.Template, error) {
 	return templates, nil
 }
 
+type OptGenerateMd5Cache bool
+type OptGenerateOverlay bool
+
 type GenerateGithubWorkflowBase struct {
 	*InputConfig
 	Version    string
 	Now        time.Time
 	ConfigFile string
 	Schedule   string
+
+	GlobalGenerateMd5Cache bool
+	GlobalGenerateOverlay  bool
 }
 
 func (b *GenerateGithubWorkflowBase) Cron() string {
@@ -394,6 +400,14 @@ func (ic *InputConfig) GenerateGithubWorkflow(file string, now time.Time, templa
 		ConfigFile:  file,
 		InputConfig: ic,
 	}
+	for _, opt := range ops {
+		switch o := opt.(type) {
+		case OptGenerateMd5Cache:
+			base.GlobalGenerateMd5Cache = bool(o)
+		case OptGenerateOverlay:
+			base.GlobalGenerateOverlay = bool(o)
+		}
+	}
 	switch ic.Type {
 	case "Github AppImage Release":
 		data = &GenerateGithubAppImageTemplateData{
@@ -464,9 +478,9 @@ func (b *GenerateGithubWorkflowBase) WorkaroundGentooVersionRegularExpression() 
 }
 
 func (b *GenerateGithubWorkflowBase) FeatureGenerateMd5Cache() bool {
-	return b.InputConfig.FeatureGenerateMd5Cache()
+	return b.GlobalGenerateMd5Cache || b.InputConfig.FeatureGenerateMd5Cache()
 }
 
 func (b *GenerateGithubWorkflowBase) FeatureGenerateOverlay() bool {
-	return b.InputConfig.FeatureGenerateOverlay()
+	return b.GlobalGenerateOverlay || b.InputConfig.FeatureGenerateOverlay()
 }

--- a/inputconfig.go
+++ b/inputconfig.go
@@ -1255,17 +1255,13 @@ func (ic *InputConfig) FeatureGenerateMd5Cache() bool {
 		return false
 	}
 	_, ok := ic.Features["Generate Md5 Cache"]
-	return ok || GenerateMd5CacheGlobal
+	return ok
 }
-
-var GenerateMd5CacheGlobal = false
 
 func (ic *InputConfig) FeatureGenerateOverlay() bool {
 	if ic.Features == nil {
 		return false
 	}
 	_, ok := ic.Features["Generate Overlay"]
-	return ok || GenerateOverlayGlobal
+	return ok
 }
-
-var GenerateOverlayGlobal = false

--- a/oneshotGithubReleaseAppImage.go
+++ b/oneshotGithubReleaseAppImage.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func CmdOneshotGithubReleaseAppImage(gitRepo, tagOverride, tagPrefix, outputDir, version string) error {
+func CmdOneshotGithubReleaseAppImage(gitRepo, tagOverride, tagPrefix, outputDir, version string, opts ...any) error {
 	ic, err := GenerateAppImageGithubReleaseConfigEntry(gitRepo, tagOverride, tagPrefix)
 	if err != nil {
 		return err
@@ -32,7 +32,7 @@ func CmdOneshotGithubReleaseAppImage(gitRepo, tagOverride, tagPrefix, outputDir,
 	}
 	now := time.Now()
 	_ = os.MkdirAll(outputDir, 0755)
-	if err := ic.GenerateGithubWorkflow("-", now, templates, outputDir, version); err != nil {
+	if err := ic.GenerateGithubWorkflow("-", now, templates, outputDir, version, opts...); err != nil {
 		return err
 	}
 	return nil

--- a/oneshotGithubReleaseBinary.go
+++ b/oneshotGithubReleaseBinary.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func CmdOneshotGithubReleaseBinary(gitRepo, tagOverride, tagPrefix, outputDir, version string) error {
+func CmdOneshotGithubReleaseBinary(gitRepo, tagOverride, tagPrefix, outputDir, version string, opts ...any) error {
 	ic, err := GenerateBinaryGithubReleaseConfigEntry(gitRepo, tagOverride, tagPrefix)
 	if err != nil {
 		return err
@@ -32,7 +32,7 @@ func CmdOneshotGithubReleaseBinary(gitRepo, tagOverride, tagPrefix, outputDir, v
 	}
 	now := time.Now()
 	_ = os.MkdirAll(outputDir, 0755)
-	if err := ic.GenerateGithubWorkflow("-", now, templates, outputDir, version); err != nil {
+	if err := ic.GenerateGithubWorkflow("-", now, templates, outputDir, version, opts...); err != nil {
 		return err
 	}
 	return nil

--- a/webAppImage.go
+++ b/webAppImage.go
@@ -114,7 +114,7 @@ func ConfigAddWebAppImage(toConfig, pageURL, matchExpr, linkExt string) error {
 }
 
 // CmdOneshotWebAppImage writes the derived configuration to stdout and renders a workflow.
-func CmdOneshotWebAppImage(pageURL, matchExpr, linkExt, outputDir, version string) error {
+func CmdOneshotWebAppImage(pageURL, matchExpr, linkExt, outputDir, version string, opts ...any) error {
 	ic, _, err := GenerateWebAppImageConfigEntry(pageURL, matchExpr, linkExt)
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ func CmdOneshotWebAppImage(pageURL, matchExpr, linkExt, outputDir, version strin
 		return err
 	}
 	_ = os.MkdirAll(outputDir, 0755)
-	if err := ic.GenerateGithubWorkflow("-", time.Now(), templates, outputDir, version); err != nil {
+	if err := ic.GenerateGithubWorkflow("-", time.Now(), templates, outputDir, version, opts...); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This branch removes the global variables for GenerateMd5Cache and GenerateOverlay. These options are now passed via a variadic argument pattern, reducing coupling and improving overall code quality.

Also fixes a subtle bug in argument parsing where global CLI flags were causing early exits in the arg processing loop, failing to parse following arguments properly.

---
*PR created automatically by Jules for task [5625444357091087181](https://jules.google.com/task/5625444357091087181) started by @arran4*