### PR TITLE
ci: add actionlint to verify generated example workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,8 @@ jobs:
               exit 1
             fi
           fi
+      - name: Run actionlint on generated examples
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@latest examples/.github/workflows/*
   go-vet:
     name: Go vet
     needs:


### PR DESCRIPTION
This adds a step in the `.github/workflows/ci.yml` `go-test` job to run `actionlint` on generated examples via `go run github.com/rhysd/actionlint/cmd/actionlint@latest examples/.github/workflows/*`. This ensures that any generated GitHub action output by the tool is statically verified for correctness.

---
*PR created automatically by Jules for task [2827011442756779554](https://jules.google.com/task/2827011442756779554) started by @arran4*